### PR TITLE
Pointwise and SubCRing constructors

### DIFF
--- a/algebra/PointWiseCRing.v
+++ b/algebra/PointWiseCRing.v
@@ -1,0 +1,175 @@
+
+Require Export CoRN.algebra.CRings.
+Section FunRing.
+
+Variable A : CSetoid.
+Variable B : CRing.
+
+Definition FSCSetoid := FS_as_CSetoid A B.
+
+Definition FS_sg_op_pointwise : FSCSetoid -> FSCSetoid -> FSCSetoid.
+  unfold FSCSetoid. intros f g.
+  apply Build_CSetoid_fun with
+    (csf_fun := (fun t : A => f t [+] g t)).
+  intros ? ? Hsep.
+  apply  csbf_strext in Hsep.
+  destruct Hsep as [Hsep| Hsep];
+    [destruct f | destruct g]; auto.
+Defined.
+
+Definition FS_sg_op_cs_pointwise : CSetoid_bin_op FSCSetoid.
+  apply Build_CSetoid_bin_op with (csbf_fun := FS_sg_op_pointwise).
+  intros f1 f2 g1 g2 Hsep.
+  simpl in Hsep.
+  unfold ap_fun in Hsep.
+  destruct Hsep as [a Hsep].
+  simpl in Hsep.
+  apply  csbf_strext in Hsep.
+  destruct Hsep;[left|right]; 
+  simpl; unfold ap_fun; eexists; eauto.
+Defined.
+
+(** There is a [FS_as_CSemiGroup] located at
+    [CoRN.algebra.CSemiGroups.FS_as_CSemiGroup]
+    It is the semigroup where the operation is
+    composition of functions. This semigroup
+    is different; it is the poinwise version
+    of the operation on B (co-domain) *)
+
+Definition FS_as_PointWise_CSemiGroup : CSemiGroup.
+  apply Build_CSemiGroup with (csg_crr := FSCSetoid)
+                            (csg_op := FS_sg_op_cs_pointwise).
+  unfold is_CSemiGroup.
+  unfold associative.
+  intros f g h. simpl.
+  unfold FS_sg_op_cs_pointwise, FS_sg_op_pointwise, eq_fun.
+  simpl. eauto  1 with algebra.
+Defined.
+
+Definition FS_cm_unit_pw : FSCSetoid.
+  unfold FSCSetoid.
+  apply Build_CSetoid_fun with
+    (csf_fun := (fun t : A => [0])).
+  intros ? ? Hsep.
+  apply ap_irreflexive_unfolded in Hsep.
+  contradiction.
+Defined.
+
+
+Definition FS_as_PointWise_CMonoid : CMonoid.
+  apply Build_CMonoid with (cm_crr := FS_as_PointWise_CSemiGroup)
+                          (cm_unit := FS_cm_unit_pw).
+  split; simpl; unfold is_rht_unit; unfold is_rht_unit; 
+  intros f; simpl; unfold eq_fun; simpl; intros a;
+  eauto using cm_rht_unit_unfolded, 
+    cm_lft_unit_unfolded.
+Defined.
+
+Definition FS_gr_inv_pw : FSCSetoid -> FSCSetoid.
+  unfold FSCSetoid. intros f.
+  apply Build_CSetoid_fun with
+    (csf_fun := (fun t : A =>  [--](f t))).
+  intros ? ? Hsep.
+  eauto using csf_strext_unfolded, zero_minus_apart,
+    csf_strext_unfolded.
+Defined.
+
+Definition FS_gr_inv_pw_cs : CSetoid_un_op FSCSetoid.
+  apply Build_CSetoid_un_op with (csf_fun := FS_gr_inv_pw).
+  intros f1 f2 Hsep. simpl.
+  simpl in Hsep.
+  unfold ap_fun in Hsep.
+  destruct Hsep as [a Hsep].
+  simpl in Hsep.
+  exists a.
+  eauto using zero_minus_apart, 
+              minus_ap_zero, csf_strext_unfolded.
+Defined.
+
+Definition FS_as_PointWise_CGroup : CGroup.
+  apply Build_CGroup with (cg_crr := FS_as_PointWise_CMonoid)
+                          (cg_inv := FS_gr_inv_pw_cs).
+  split; simpl;
+  unfold eq_fun;
+  unfold FS_sg_op_pointwise, FS_cm_unit_pw, FS_gr_inv_pw;
+  simpl; eauto using cg_rht_inv_unfolded,
+                     cg_lft_inv_unfolded.
+Defined.
+
+Definition FS_as_PointWise_CAbGroup : CAbGroup.
+  apply Build_CAbGroup with (cag_crr := FS_as_PointWise_CGroup).
+  unfold is_CAbGroup, commutes.
+  intros f g. simpl. unfold eq_fun.
+  simpl. eauto with algebra.
+Defined.
+
+Definition FS_mult_pointwise : 
+    FSCSetoid -> FSCSetoid -> FSCSetoid.
+  unfold FSCSetoid. intros f g.
+  apply Build_CSetoid_fun with
+    (csf_fun := (fun t : A => f t [*] g t)).
+  intros ? ? Hsep.
+  apply  csbf_strext in Hsep.
+  destruct Hsep as [Hsep| Hsep];
+    [destruct f | destruct g]; auto.
+Defined.
+
+Definition FS_mult_pointwise_cs : CSetoid_bin_op FSCSetoid.
+  apply Build_CSetoid_bin_op with (csbf_fun := FS_mult_pointwise).
+  intros f1 f2 g1 g2 Hsep.
+  simpl in Hsep.
+  unfold ap_fun in Hsep.
+  destruct Hsep as [a Hsep].
+  simpl in Hsep.
+  apply  csbf_strext in Hsep.
+  destruct Hsep;[left|right]; 
+  simpl; unfold ap_fun; eexists; eauto.
+Defined.
+
+Definition FS_cg_one_pw : FSCSetoid.
+  unfold FSCSetoid.
+  apply Build_CSetoid_fun with
+    (csf_fun := (fun t : A => [1])).
+  intros ? ? Hsep.
+  apply ap_irreflexive_unfolded in Hsep.
+  contradiction.
+Defined.
+
+Lemma FS_mult_pointwise_assoc 
+  : associative FS_mult_pointwise.
+ unfold associative.
+  intros f g h a. simpl.
+  eauto  1 with algebra.
+Defined.
+
+(** To prove that the unit of multiplication
+    is not the same as the unit of addition,
+    ,i.e. [1] [#] [0], i.e. [ax_non_triv],
+    [A] must be non-empty.
+    Otherwise the extensional equality on 
+    function space means that
+    [fun _ => [0]] [=] [fun _ => [1]]
+*)
+
+Variable aa : A.
+
+Definition FS_as_PointWise_CRing : CRing.
+  apply Build_CRing with (cr_crr := FS_as_PointWise_CAbGroup)
+                         (cr_mult := FS_mult_pointwise_cs)
+                         (cr_one := FS_cg_one_pw).
+  apply Build_is_CRing 
+    with (ax_mult_assoc := FS_mult_pointwise_assoc);
+  simpl.
+- split; simpl; unfold is_rht_unit; unfold is_rht_unit; 
+  intros f; simpl; unfold eq_fun; simpl; intros a;
+  eauto using mult_one, one_mult.
+- intros f g a. simpl. apply mult_commut_unfolded.
+- intros f g h a. simpl. apply  ring_dist_unfolded.
+- unfold ap_fun. exists aa. simpl.
+  apply ring_non_triv.
+Defined.
+
+End FunRing.
+
+
+

--- a/algebra/SubCRing.v
+++ b/algebra/SubCRing.v
@@ -1,0 +1,143 @@
+Require Export CoRN.algebra.CRings.
+Set Implicit Arguments.
+Section SubRing.
+
+Variable A : CRing.
+Variable AProp : A -> Type.
+
+Definition SubCSetoid := Build_SubCSetoid  A AProp.
+Hint Resolve (scs_prf A AProp) : CoRN.
+
+Variable AProp_closed_csg_op :
+   forall {a1 a2 : A}, 
+    AProp a1
+    -> AProp a2
+    -> AProp (a1 [+] a2).
+
+Definition Sub_sg_op (a1 a2 : SubCSetoid) : SubCSetoid :=
+{|
+    scs_elem := a1[+]a2;
+    scs_prf := AProp_closed_csg_op (scs_prf _ _ a1)
+                                   (scs_prf _ _ a2) |}.
+
+Definition Sub_sg_op_cs : CSetoid_bin_op SubCSetoid.
+  apply Build_CSetoid_bin_op with (csbf_fun := Sub_sg_op).
+  intros a b c d  Hsep.
+  simpl in Hsep.
+  destruct a,b,c,d.
+  simpl. simpl in Hsep.
+  apply  csbf_strext in Hsep.
+  destruct Hsep;[left|right]; 
+  simpl; unfold ap_fun; eauto.
+Defined.
+
+Definition SubCSemiGroup : CSemiGroup.
+  apply Build_CSemiGroup with (csg_crr := SubCSetoid)
+                            (csg_op := Sub_sg_op_cs).
+  unfold is_CSemiGroup.
+  unfold associative.
+  intros. simpl.
+  simpl. eauto  1 with algebra.
+Defined.
+
+Variable Aprop0 : AProp [0].
+
+Definition Sub_cm_unit: SubCSetoid :=
+  {| scs_elem := [0] ; scs_prf := Aprop0|}.
+
+
+Definition SubCMonoid : CMonoid.
+  apply Build_CMonoid with (cm_crr := SubCSemiGroup)
+                          (cm_unit := Sub_cm_unit).
+  split; simpl; unfold is_rht_unit; unfold is_rht_unit; 
+  intros f; destruct f; simpl; unfold eq_fun; simpl;
+  eauto using cm_rht_unit_unfolded, 
+    cm_lft_unit_unfolded.
+Defined.
+
+Variable AProp_closed_cg_inv :
+   forall {a : A}, 
+    AProp a
+    -> AProp ([--] a).
+
+Definition Sub_gr_inv (a :SubCSetoid) : SubCSetoid :=
+{| scs_elem := [--]a ; 
+   scs_prf :=  AProp_closed_cg_inv (scs_prf _ _ a)|}.
+
+
+Definition Sub_gr_inv_cs : CSetoid_un_op SubCSetoid.
+  apply Build_CSetoid_un_op with (csf_fun := Sub_gr_inv).
+  intros a1 a2 Hsep. destruct a1, a2.
+  simpl in Hsep.
+  simpl.
+  eauto using zero_minus_apart, 
+              minus_ap_zero, csf_strext_unfolded.
+Defined.
+
+Definition SubCGroup : CGroup.
+  apply Build_CGroup with (cg_crr := SubCMonoid)
+                          (cg_inv := Sub_gr_inv_cs).
+  split; simpl;
+  simpl; eauto using cg_rht_inv_unfolded,
+                     cg_lft_inv_unfolded.
+Defined.
+
+Definition SubCAbGroup : CAbGroup.
+  apply Build_CAbGroup with (cag_crr := SubCGroup).
+  unfold is_CAbGroup, commutes.
+  simpl. eauto with algebra.
+Defined.
+
+Variable AProp_closed_cr_mult :
+   forall {a1 a2 : A}, 
+    AProp a1
+    -> AProp a2
+    -> AProp (a1 [*] a2).
+
+Definition Sub_cr_mult (a1 a2 : SubCSetoid) : SubCSetoid :=
+{|
+    scs_elem := a1[*]a2;
+    scs_prf := AProp_closed_cr_mult (scs_prf _ _ a1)
+                                    (scs_prf _ _ a2) |}.
+
+Definition Sub_cr_mult_cs : CSetoid_bin_op SubCSetoid.
+  apply Build_CSetoid_bin_op with (csbf_fun := Sub_cr_mult).
+  intros a b c d  Hsep.
+  simpl in Hsep.
+  destruct a,b,c,d.
+  simpl. simpl in Hsep.
+  apply  csbf_strext in Hsep.
+  destruct Hsep;[left|right]; 
+  simpl; unfold ap_fun; eauto.
+Defined.
+
+Variable Aprop1 : AProp [1].
+
+Definition Sub_cr_one: SubCSetoid :=
+  {| scs_elem := [1] ; scs_prf := Aprop1|}.
+
+Lemma Sub_mult_assoc : associative Sub_cr_mult_cs.
+  unfold associative.
+  intros f g h. simpl.
+  eauto  1 with algebra.
+Defined.
+
+
+Definition SubCRing : CRing.
+  apply Build_CRing with (cr_crr := SubCAbGroup)
+                         (cr_mult := Sub_cr_mult_cs)
+                         (cr_one := Sub_cr_one).
+  apply Build_is_CRing 
+    with (ax_mult_assoc := Sub_mult_assoc);
+  simpl.
+- split; simpl; unfold is_rht_unit; unfold is_rht_unit; 
+  intros f; destruct f; simpl;
+  eauto using mult_one, one_mult. 
+- intros f g . simpl. apply mult_commut_unfolded.
+- intros f g h. simpl. apply  ring_dist_unfolded.
+- unfold ap_fun. 
+  apply ring_non_triv.
+Defined.
+
+End SubRing.
+


### PR DESCRIPTION
added the 2 CRing constructors requested in
https://sympa.inria.fr/sympa/arc/coq-club/2015-01/msg00026.html

1) given a setoid A and a ring B, and an element a of A, PointWiseCRing.FS_as_PointWise_CRing A B a is a ring over the setoid representing A -> B where the operations (e.g. +, *) are just the corresponding operations on B (pointwise)

2) Given a ring B and a property (B -> Type) that respects the equality on the underlying setoid of B, and proofs that the ring operations on B are closed under the property,
SubCRing B _ ... _ is a sub CRing of B

The application I have in mind is to construct a ring of real-valued continuous functions.