### PR TITLE
many lemmas about sin, cos, arctan.

### DIFF
--- a/reals/fast/CRIR.v
+++ b/reals/fast/CRIR.v
@@ -472,3 +472,13 @@ Proof.
   reflexivity.
 Qed.
 
+Lemma IRasCR_preserves_less : 
+  forall x y, (x[<]y -> IRasCR x < IRasCR y)%CR.
+Proof.
+ intros x y H.
+  pose proof (iso_map_rht _ _ CRIR_iso).
+  simpl. 
+  apply (map_pres_less _ _  (iso_map_rht _ _ CRIR_iso)) in H.
+  simpl in H.
+  exact H.
+Qed.

--- a/reals/fast/CRIR.v
+++ b/reals/fast/CRIR.v
@@ -445,3 +445,30 @@ Proof.
   rewrite IRasCRasIR_id in HH.
   symmetry. exact HH.
 Qed.
+
+Lemma CR_plus_asIR :
+∀ x y : CR , CRasIR (x+y) = (CRasIR x [+] CRasIR y).
+Proof.
+  intros x y.
+  pose proof (IR_plus_as_CR (CRasIR x) (CRasIR y)) as HH.
+  rewrite CRasIRasCR_id in HH.
+  rewrite CRasIRasCR_id in HH.
+  apply CRasIR_wd in HH.
+  rewrite <- HH.
+  rewrite IRasCRasIR_id.
+  reflexivity.
+Qed.
+
+Lemma CR_mult_asIR :
+∀ x y : CR , CRasIR (x*y) = (CRasIR x [*] CRasIR y).
+Proof.
+  intros x y.
+  pose proof (IR_mult_as_CR (CRasIR x) (CRasIR y)) as HH.
+  rewrite CRasIRasCR_id in HH.
+  rewrite CRasIRasCR_id in HH.
+  apply CRasIR_wd in HH.
+  rewrite <- HH.
+  rewrite IRasCRasIR_id.
+  reflexivity.
+Qed.
+

--- a/reals/fast/CRIR.v
+++ b/reals/fast/CRIR.v
@@ -427,3 +427,21 @@ Proof.
   rewrite CRasIRasCR_id, CRasIRasCR_id.
   reflexivity.
 Qed.
+
+Lemma CR_leEq_as_IR :
+∀ x y : CR , x ≤ y ↔ (CRasIR x [<=] CRasIR y).
+Proof.
+  intros x y.
+  pose proof (IR_leEq_as_CR (CRasIR x) (CRasIR y)) as HH.
+  rewrite CRasIRasCR_id in HH.
+  rewrite CRasIRasCR_id in HH.
+  symmetry. exact HH.
+Qed.
+
+Lemma CRasIR0 : CRasIR 0 = [0].
+Proof.
+  pose proof IR_Zero_as_CR as HH.
+  apply CRasIR_wd in HH.
+  rewrite IRasCRasIR_id in HH.
+  symmetry. exact HH.
+Qed.

--- a/reals/fast/CRIR.v
+++ b/reals/fast/CRIR.v
@@ -397,3 +397,33 @@ Proof.
  rewrite -> IR_opp_as_CR.
  reflexivity.
 Qed.
+
+Require Import MathClasses.interfaces.abstract_algebra.
+
+Instance Injective_instance_CRasIR : Injective  CRasIR.
+  constructor.
+- intros ? ? Heq. apply (fun_strext_imp_wd _ _ IRasCR) in Heq;
+    [ | apply R_morphism.map_strext].
+  repeat( rewrite CRasIRasCR_id in Heq).
+  exact Heq.
+- constructor;eauto 2 with *.
+  exact CRasIR_wd.
+Qed.
+
+Instance Injective_instance_IRasCR : Injective  IRasCR.
+  constructor.
+- intros ? ? Heq. apply (fun_strext_imp_wd _ _ CRasIR) in Heq;
+    [ | apply R_morphism.map_strext].
+  repeat (rewrite IRasCRasIR_id in Heq).
+  exact Heq.
+- constructor; try apply st_isSetoid.
+  exact IRasCR_wd.
+Qed.
+
+Lemma CRasIR_inv :  forall x, (CRasIR (- x) = [--] (CRasIR x))%CR.
+Proof.
+  intros. apply (injective IRasCR).
+  rewrite IR_opp_as_CR.
+  rewrite CRasIRasCR_id, CRasIRasCR_id.
+  reflexivity.
+Qed.

--- a/reals/fast/CRSinCos.v
+++ b/reals/fast/CRSinCos.v
@@ -1,0 +1,134 @@
+(** These are lemmas about IR versions of Sin and Cos
+    ported to CR *)
+
+Require Import CRcos.
+Require Import CRpi.
+Require Import CRsin.
+Require Import CRIR.
+Require Import MathClasses.interfaces.canonical_names.
+Require Import MathClasses.interfaces.abstract_algebra.
+
+Lemma sr_mult_associative `{SemiRing R} (x y z : R) : 
+    (x * (y * z) = x * y * z).
+Proof. apply sg_ass, _. Qed.
+
+Lemma inject_Q_CR_one  : (inject_Q_CR (1#1) [=] 1)%CR.
+ring.
+Qed.
+
+Lemma inject_Q_CR_two  : (inject_Q_CR (2#1) = 2)%CR.
+  rewrite <- inject_Q_CR_one.
+  destruct CR_Q_ring_morphism.
+  idtac. unfold plus, CRplus. rewrite <- morph_add; eauto.
+Qed.
+
+Definition QCRM := CR_Q_ring_morphism.
+
+Lemma CR_Cos_HalfPi : (cos (CRpi * ' (1 # 2)) = 0 )%CR.
+Proof.
+  pose proof (Pi.Cos_HalfPi) as Hc.
+  apply IRasCR_wd in Hc.
+  autorewrite with IRtoCR in Hc.
+  rewrite <- Hc.
+  apply sm_proper.
+  apply (right_cancellation mult 2).
+  match goal with 
+  [ |- ?l = _] => remember l as ll
+  end.
+  rewrite <- IR_One_as_CR.
+  unfold plus. unfold CRplus.
+  rewrite <- IR_plus_as_CR.
+  rewrite <- IR_mult_as_CR.
+  subst.
+  apply (injective CRasIR).
+  rewrite IRasCRasIR_id.
+  rewrite one_plus_one.
+  rewrite div_1.
+  apply (injective IRasCR).
+  rewrite CRasIRasCR_id.
+  rewrite CRpi_correct.
+  fold (mult).
+  rewrite <- sr_mult_associative.
+  match goal with 
+  [ |- ?l = _] => remember l as ll
+  end.
+  assert (CRpi [=] CRpi * 1)%CR as Hr by ring.
+  rewrite Hr.
+  subst ll.
+  fold (mult).
+  simpl. apply sg_op_proper;[reflexivity|].
+  rewrite <- inject_Q_CR_two.
+  rewrite <- (morph_mul QCRM).
+  apply (morph_eq QCRM).
+  reflexivity.
+Qed.
+
+Lemma CRCos_inv : forall x, (cos (-x) = cos x )%CR.
+Proof.
+  intros. rewrite <- cos_correct_CR, <- cos_correct_CR.
+  apply IRasCR_wd.
+  rewrite <- SinCos.Cos_inv.
+  apply SinCos.Cos_wd.
+  
+  pose proof (Pi.Cos_HalfPi) as Hc.
+  apply IRasCR_wd in Hc.
+  autorewrite with IRtoCR in Hc.
+  rewrite <-  CRasIR_inv.
+  apply CRasIR_wd.
+  ring.
+Qed.
+
+Lemma CR_Sin_HalfPi : (sin (CRpi * ' (1 # 2)) = 1 )%CR.
+Proof.
+  pose proof (Pi.Sin_HalfPi) as Hc.
+  apply IRasCR_wd in Hc.
+  autorewrite with IRtoCR in Hc.
+  rewrite <- Hc.
+  apply sm_proper.
+  apply (right_cancellation mult 2).
+  match goal with 
+  [ |- ?l = _] => remember l as ll
+  end.
+  rewrite <- IR_One_as_CR.
+  unfold plus. unfold CRplus.
+  rewrite <- IR_plus_as_CR.
+  rewrite <- IR_mult_as_CR.
+  subst.
+  apply (injective CRasIR).
+  rewrite IRasCRasIR_id.
+  rewrite one_plus_one.
+  rewrite div_1.
+  apply (injective IRasCR).
+  rewrite CRasIRasCR_id.
+  rewrite CRpi_correct.
+  fold (mult).
+  rewrite <- sr_mult_associative.
+  match goal with 
+  [ |- ?l = _] => remember l as ll
+  end.
+  assert (CRpi [=] CRpi * 1)%CR as Hr by ring.
+  rewrite Hr.
+  subst ll.
+  fold (mult).
+  simpl. apply sg_op_proper;[reflexivity|].
+  rewrite <- inject_Q_CR_two.
+  rewrite <- (morph_mul QCRM).
+  apply (morph_eq QCRM).
+  reflexivity.
+Qed.
+
+Lemma CRSin_inv : forall x, (sin (-x) = - sin x )%CR.
+Proof.
+  intros. rewrite <- sin_correct_CR, <- sin_correct_CR.
+  rewrite <- IR_opp_as_CR.
+  apply IRasCR_wd.
+  rewrite <- SinCos.Sin_inv.
+  apply SinCos.Sin_wd.
+  
+  pose proof (Pi.Cos_HalfPi) as Hc.
+  apply IRasCR_wd in Hc.
+  autorewrite with IRtoCR in Hc.
+  rewrite <-  CRasIR_inv.
+  apply CRasIR_wd.
+  ring.
+Qed.

--- a/reals/fast/CRSinCos.v
+++ b/reals/fast/CRSinCos.v
@@ -132,3 +132,164 @@ Proof.
   apply CRasIR_wd.
   ring.
 Qed.
+
+
+Require Import CRpower.
+Require Import  MathClasses.interfaces.additional_operations.
+Lemma CRpower_N_asIR:
+  ∀ (n: N) (x : CR), 
+    CRasIR (x ^ n) = (((CRasIR x) [^] (N.to_nat n))%CR) .
+Proof.
+  intros ? ?.
+  apply (injective IRasCR).
+  rewrite CRpower_N_correct.
+  rewrite CRasIRasCR_id.
+  rewrite CRasIRasCR_id.
+  reflexivity.
+Qed.
+
+Hint Rewrite CRasIR0 CRasIR_inv CR_mult_asIR 
+  CR_plus_asIR CRpower_N_asIR: CRtoIR .
+
+
+Ltac prepareForCRRing := 
+  unfold zero, one, CR1, stdlib_rationals.Q_0, mult, cast,
+  plus, CRplus,
+  canonical_names.negate.
+
+Ltac CRRing :=
+    prepareForCRRing;
+    let H:= fresh "H" in
+    match goal with
+    [|-equiv ?l ?r] => assert (st_eq l  r) as H by ring;
+                       rewrite <- H; clear H; reflexivity
+    end.
+
+Lemma CRdivideToMul: 
+  forall na da dap nb db dbp,
+  na*db = nb*da -> na // (da ↾ dap) = nb // (db ↾ dbp).
+Proof.
+  simpl. intros ? ? ? ? ? ? Heq.
+  apply  fields.equal_quotients.
+  simpl.
+  exact Heq.
+Qed.
+
+Definition mkCr0 (a : CR) (ap : (a >< 0)%CR)  : CR ₀.
+  exists a. simpl. apply CR_apart_apartT in ap.
+  exact ap.
+Defined.
+
+Lemma  CRinv_CRinvT : forall
+  (a : CR) (ap : (a >< 0)%CR),
+  CRinvT a ap = CRinv (mkCr0 a ap).
+Proof.
+  intros. unfold CRinv.
+  simpl. apply CRinvT_wd.
+  reflexivity.
+Qed.
+
+
+
+Lemma CRdivideToMulCRInvT: 
+  forall na da dap nb db dbp,
+  na*db = nb*da -> na * (CRinvT da  dap) = nb * (CRinvT db  dbp).
+Proof.
+  intros ? ? ? ? ? ? Heq.
+  rewrite CRinv_CRinvT, CRinv_CRinvT.
+  apply    fields.equal_quotients.
+  simpl.
+  exact Heq.
+Qed.
+Lemma CRpower_N_2 : forall y,
+    CRpower_N y (N.of_nat 2) = y * y.
+Proof.
+  intros y.
+  assert ((N.of_nat 2) = (1+(1+0))) as Hs by reflexivity.
+  rewrite Hs.
+  destruct NatPowSpec_instance_0.
+  rewrite nat_pow_S.
+  rewrite nat_pow_S.
+  rewrite nat_pow_0.
+  simpl. prepareForCRRing.
+  unfold CR1. CRRing.
+Qed.
+
+Require Import CRarctan.
+Require Import MoreArcTan.
+
+Lemma sqr_o_cos_o_arctan : forall r p,
+    (cos (arctan r)) ^2 = (1 //((1 + r^2) ↾ p)).
+Proof.
+  intros x p. simpl in p.
+  pose proof (CosOfArcTan2 (CRasIR x)) as Hc.
+  apply IRasCR_wd in Hc.
+  autorewrite with IRtoCR in Hc.
+  rewrite CRasIRasCR_id in Hc.
+  rewrite Hc. clear Hc.
+  rewrite IR_div_as_CR_1.
+  simpl. unfold cf_div. unfold f_rcpcl, f_rcpcl'.
+  simpl. unfold recip,CRinv. 
+  apply CRdivideToMulCRInvT.
+  autorewrite with IRtoCR.
+  rewrite CRasIRasCR_id.
+  simpl. rewrite CRpower_N_2.
+  prepareForCRRing.
+  simpl. CRRing.
+Qed.
+
+Lemma sqr_o_sin_o_arctan : forall r p,
+    (sin (arctan r)) ^2 = (r^2 //((1 + r^2) ↾ p)).
+Proof.
+  intros x p. simpl in p.
+  pose proof (SinOfArcTan2 (CRasIR x)) as Hc.
+  apply IRasCR_wd in Hc.
+  autorewrite with IRtoCR in Hc.
+  rewrite CRasIRasCR_id in Hc.
+  rewrite Hc. clear Hc.
+  rewrite IR_div_as_CR_1.
+  simpl. unfold cf_div. unfold f_rcpcl, f_rcpcl'.
+  simpl. unfold recip,CRinv. 
+  apply CRdivideToMulCRInvT.
+  autorewrite with IRtoCR.
+  rewrite CRasIRasCR_id.
+  simpl. rewrite CRpower_N_2.
+  prepareForCRRing.
+  simpl.  CRRing.
+Qed.
+
+Lemma CRApart_wdl :forall a b c:CR, 
+  a = b -> a ≶ c -> b ≶ c.
+Proof.
+  intros ? ? ? Heq.
+  apply strong_setoids.apart_proper; auto.
+Qed.
+
+
+Lemma  OnePlusSqrPos : forall r:CR, (1 + r ^ 2) ≶ 0.
+Proof.
+  intros.
+  symmetry.
+  apply orders.lt_iff_le_apart.
+  apply semirings.pos_plus_le_lt_compat_l; auto.
+  simpl. apply semirings.lt_0_1.
+  apply CR_leEq_as_IR.
+  autorewrite with CRtoIR.
+  apply sqr_nonneg.
+Qed.
+
+Definition mkCr0' (a : CR) (ap : (a ≶ 0)%CR)  : CR ₀ :=
+   (a ↾ ap).
+
+Lemma sqr_o_cos_o_arctan2 : forall r,
+    (cos (arctan r)) ^2 = (1 //(mkCr0' (1 + r^2) (OnePlusSqrPos _))).
+Proof.
+  intros. apply sqr_o_cos_o_arctan.
+Qed.
+
+Lemma sqr_o_sin_o_arctan2 : forall r,
+    (sin (arctan r)) ^2 = (r^2 //(mkCr0' (1 + r^2) (OnePlusSqrPos _))).
+Proof.
+  intros. apply sqr_o_sin_o_arctan.
+Qed.
+

--- a/reals/fast/CRSinCos.v
+++ b/reals/fast/CRSinCos.v
@@ -22,15 +22,45 @@ Lemma inject_Q_CR_two  : (inject_Q_CR (2#1) = 2)%CR.
   idtac. unfold plus, CRplus. rewrite <- morph_add; eauto.
 Qed.
 
+Require Import CRpower.
+Require Import  MathClasses.interfaces.additional_operations.
+Lemma CRpower_N_asIR:
+  ∀ (n: N) (x : CR), 
+    CRasIR (x ^ n) = (((CRasIR x) [^] (N.to_nat n))%CR) .
+Proof.
+  intros ? ?.
+  apply (injective IRasCR).
+  rewrite CRpower_N_correct.
+  rewrite CRasIRasCR_id.
+  rewrite CRasIRasCR_id.
+  reflexivity.
+Qed.
+
+Hint Rewrite CRasIR0 CRasIR_inv CR_mult_asIR 
+  CR_plus_asIR CRpower_N_asIR: CRtoIR .
+
+
+Lemma CREquiv_st_eq: forall a b : CR,
+  st_eq (r:=CR) a  b <-> a = b.
+Proof.
+  reflexivity.
+Qed.
+
+Ltac prepareForCRRing := 
+  unfold zero, one, CR1, stdlib_rationals.Q_0, mult, cast,
+  plus, CRplus,
+  canonical_names.negate;
+  try apply (proj1 (CREquiv_st_eq _ _)).
+
+
+Ltac CRRing :=
+    prepareForCRRing; ring.
+
 Definition QCRM := CR_Q_ring_morphism.
 
-Lemma CR_Cos_HalfPi : (cos (CRpi * ' (1 # 2)) = 0 )%CR.
+Lemma CRPiBy2Correct :
+  (CRpi * ' (1 # 2))%CR = IRasCR (Pi.Pi [/]TwoNZ).
 Proof.
-  pose proof (Pi.Cos_HalfPi) as Hc.
-  apply IRasCR_wd in Hc.
-  autorewrite with IRtoCR in Hc.
-  rewrite <- Hc.
-  apply sm_proper.
   apply (right_cancellation mult 2).
   match goal with 
   [ |- ?l = _] => remember l as ll
@@ -61,6 +91,16 @@ Proof.
   rewrite <- (morph_mul QCRM).
   apply (morph_eq QCRM).
   reflexivity.
+Qed.
+
+Lemma CR_Cos_HalfPi : (cos (CRpi * ' (1 # 2)) = 0 )%CR.
+Proof.
+  pose proof (Pi.Cos_HalfPi) as Hc.
+  apply IRasCR_wd in Hc.
+  autorewrite with IRtoCR in Hc.
+  rewrite <- Hc.
+  apply sm_proper.
+  apply CRPiBy2Correct.
 Qed.
 
 Lemma CRCos_inv : forall x, (cos (-x) = cos x )%CR.
@@ -78,6 +118,19 @@ Proof.
   ring.
 Qed.
 
+
+Lemma CR_Cos_Neg_HalfPi : (cos (CRpi * ' (-1 # 2)) = 0 )%CR.
+Proof.
+  rewrite <- CRCos_inv.
+  rewrite <- CR_Cos_HalfPi.
+  apply sm_proper.
+  assert  (((-1#2)) = Qopp (1#2)) as Heq by reflexivity.
+  rewrite Heq. clear Heq.
+  rewrite (morph_opp QCRM).
+  generalize (inject_Q_CR(1 # 2)).
+  intros.  CRRing. 
+Qed.
+
 Lemma CR_Sin_HalfPi : (sin (CRpi * ' (1 # 2)) = 1 )%CR.
 Proof.
   pose proof (Pi.Sin_HalfPi) as Hc.
@@ -85,36 +138,7 @@ Proof.
   autorewrite with IRtoCR in Hc.
   rewrite <- Hc.
   apply sm_proper.
-  apply (right_cancellation mult 2).
-  match goal with 
-  [ |- ?l = _] => remember l as ll
-  end.
-  rewrite <- IR_One_as_CR.
-  unfold plus. unfold CRplus.
-  rewrite <- IR_plus_as_CR.
-  rewrite <- IR_mult_as_CR.
-  subst.
-  apply (injective CRasIR).
-  rewrite IRasCRasIR_id.
-  rewrite one_plus_one.
-  rewrite div_1.
-  apply (injective IRasCR).
-  rewrite CRasIRasCR_id.
-  rewrite CRpi_correct.
-  fold (mult).
-  rewrite <- sr_mult_associative.
-  match goal with 
-  [ |- ?l = _] => remember l as ll
-  end.
-  assert (CRpi [=] CRpi * 1)%CR as Hr by ring.
-  rewrite Hr.
-  subst ll.
-  fold (mult).
-  simpl. apply sg_op_proper;[reflexivity|].
-  rewrite <- inject_Q_CR_two.
-  rewrite <- (morph_mul QCRM).
-  apply (morph_eq QCRM).
-  reflexivity.
+  apply CRPiBy2Correct.
 Qed.
 
 Lemma CRSin_inv : forall x, (sin (-x) = - sin x )%CR.
@@ -134,36 +158,6 @@ Proof.
 Qed.
 
 
-Require Import CRpower.
-Require Import  MathClasses.interfaces.additional_operations.
-Lemma CRpower_N_asIR:
-  ∀ (n: N) (x : CR), 
-    CRasIR (x ^ n) = (((CRasIR x) [^] (N.to_nat n))%CR) .
-Proof.
-  intros ? ?.
-  apply (injective IRasCR).
-  rewrite CRpower_N_correct.
-  rewrite CRasIRasCR_id.
-  rewrite CRasIRasCR_id.
-  reflexivity.
-Qed.
-
-Hint Rewrite CRasIR0 CRasIR_inv CR_mult_asIR 
-  CR_plus_asIR CRpower_N_asIR: CRtoIR .
-
-
-Ltac prepareForCRRing := 
-  unfold zero, one, CR1, stdlib_rationals.Q_0, mult, cast,
-  plus, CRplus,
-  canonical_names.negate.
-
-Ltac CRRing :=
-    prepareForCRRing;
-    let H:= fresh "H" in
-    match goal with
-    [|-equiv ?l ?r] => assert (st_eq l  r) as H by ring;
-                       rewrite <- H; clear H; reflexivity
-    end.
 
 Lemma CRdivideToMul: 
   forall na da dap nb db dbp,
@@ -293,3 +287,173 @@ Proof.
   intros. apply sqr_o_sin_o_arctan.
 Qed.
 
+Lemma  CRltT_wdl : ∀ x1 x2 y : CR,
+       x1 = x2  → (x1 < y)%CR → (x2 < y)%CR.
+Proof.
+  intros ? ? ? Heq.
+  apply CRltT_wd; auto.
+  reflexivity.
+Qed.
+
+Lemma  CRltT_wdr : ∀ x1 x2 y : CR,
+       x1 = x2  → (y < x1)%CR → (y < x2)%CR.
+Proof.
+  intros ? ? ? Heq.
+  apply CRltT_wd; auto.
+  reflexivity.
+Qed.
+
+Class RealNumberPi (R : Type) := π : R.
+Instance CRpi_RealNumberPi_instance : RealNumberPi CR := CRpi.
+
+Class HalfNum (R : Type) := half_num : R.
+Notation "½" := half_num.
+Instance Q_Half_instance : HalfNum Q := (1#2)%Q.
+Instance CR_Half_instance : HalfNum CR := (inject_Q_CR (1#2)%Q).
+
+Close Scope Q_scope.
+
+Lemma CRCos_plus_Pi: ∀θ , cos (θ + π) = - (cos θ).
+  intros θ.
+  pose proof (Pi.Cos_plus_Pi (CRasIR θ)) as Hc.
+  apply IRasCR_wd in Hc.
+  autorewrite with IRtoCR in Hc.
+  rewrite CRasIRasCR_id in Hc.
+  exact Hc.
+Qed.
+
+Lemma CRSin_plus_Pi: ∀ θ : CR, sin (θ + π) = (- sin θ).
+  intros x.
+  pose proof (Pi.Sin_plus_Pi (CRasIR x)) as Hc.
+  apply IRasCR_wd in Hc.
+  autorewrite with IRtoCR in Hc.
+  rewrite CRasIRasCR_id in Hc.
+  exact Hc.
+Qed.
+
+Lemma sin_correct_CR : ∀ θ,
+  CRasIR (sin θ) = (PowerSeries.Sin (CRasIR θ)).
+Proof.
+  intros θ. apply (injective IRasCR). rewrite sin_correct.
+  rewrite CRasIRasCR_id,CRasIRasCR_id. reflexivity.
+Qed.
+
+Lemma cos_correct_CR : ∀ θ,
+  CRasIR (cos θ) = (PowerSeries.Cos (CRasIR θ)).
+Proof.
+  intros θ. apply (injective IRasCR). rewrite cos_correct.
+  rewrite CRasIRasCR_id,CRasIRasCR_id. reflexivity.
+Qed.
+
+Lemma arctan_correct_CR : ∀ θ,
+  CRasIR (arctan θ) = (ArcTan (CRasIR θ)).
+Proof.
+  intros θ. apply (injective IRasCR). rewrite arctan_correct.
+  rewrite CRasIRasCR_id,CRasIRasCR_id. reflexivity.
+Qed.
+
+
+Hint Rewrite sin_correct_CR cos_correct_CR : CRtoIR.
+
+(** One could also divide [π] by 2. However,
+    division seems to be annoyingly difficult to deal with.
+    For example, rewrite fails with an error about
+    inability to handle dependence. Also, one has
+    to carry around proofs of positivity *)
+
+Lemma CRPiBy2Correct1 :
+  ½ * π = IRasCR (Pi.Pi [/]TwoNZ).
+Proof.
+  rewrite <- CRPiBy2Correct.
+  rewrite rings.mult_comm.
+  reflexivity.
+Qed.
+
+Lemma MinusCRPiBy2Correct :
+  - (½ * π) = IRasCR ([--] (Pi.Pi [/]TwoNZ)).
+Proof.
+  autorewrite with IRtoCR.
+  rewrite <- CRPiBy2Correct.
+  rewrite rings.mult_comm.
+  reflexivity.
+Qed.
+
+Lemma CRCos_nonneg:
+  ∀ θ, -(½ * π) ≤ θ ≤ ½ * π
+        → 0 ≤ cos θ.
+Proof.
+  intros ? Hp. destruct Hp as [Hpt Htp].
+  pose proof (TrigMon.Cos_nonneg (CRasIR θ)) as Hir.
+  apply CR_leEq_as_IR.
+  autorewrite with CRtoIR.
+  rewrite CRPiBy2Correct1 in Htp.
+  apply CR_leEq_as_IR in Htp.
+  rewrite IRasCRasIR_id in Htp.
+  apply Hir; trivial;[].
+  clear Htp Hir.
+  apply IR_leEq_as_CR.
+  rewrite CRasIRasCR_id.
+  rewrite  <- MinusCRPiBy2Correct.
+  exact Hpt.
+Qed.
+
+
+
+Lemma CRarctan_range:
+ ∀ r : CR, (-(½ * π) < arctan r < ½ * π).
+Proof.
+  intros r.
+  pose proof (InvTrigonom.ArcTan_range (CRasIR r)) as Hir.
+  destruct Hir as [Hirl Hirr].
+  eapply less_wdl in Hirr;
+    [|symmetry; apply arctan_correct_CR].
+  eapply less_wdr in Hirl;
+    [| symmetry; apply arctan_correct_CR].
+  apply IRasCR_preserves_less in Hirr.
+  apply IRasCR_preserves_less in Hirl.
+  eapply CRltT_wdr in Hirl;
+    [| apply CRasIRasCR_id].
+  eapply CRltT_wdl in Hirr;
+    [| apply CRasIRasCR_id].
+  eapply CRltT_wdr in Hirr;
+    [| symmetry; apply CRPiBy2Correct1].
+  split; unfold lt; apply CR_lt_ltT; auto;[].
+  clear Hirr.
+  eapply CRltT_wdl in Hirl;
+    [| symmetry; apply MinusCRPiBy2Correct].
+  assumption.
+Qed.
+
+
+Lemma CRweakenLt :
+  ∀ a t: CR, a < t -> a ≤ t.
+Proof.
+  intros ? ? Hlt.
+  apply orders.full_pseudo_srorder_le_iff_not_lt_flip.
+  intros Hc.
+  pose proof (conj Hc Hlt) as Hr.
+  apply orders.pseudo_order_antisym in Hr.
+  assumption.
+Qed.
+
+Hint Resolve CRweakenLt : CRBasics.
+
+
+Lemma CRweakenRange :
+  ∀ a t b: CR,
+    a < t < b
+    -> a ≤ t ≤ b.
+Proof.
+  intros ? ? ? Hr.
+  destruct Hr.
+  split; eauto using CRweakenLt.
+Qed.
+
+Lemma cos_o_arctan_nonneg: 
+  ∀ r : CR,  0 ≤ cos (arctan r).
+Proof.
+  intros ?.
+  apply CRCos_nonneg.
+  apply CRweakenRange.
+  apply CRarctan_range.
+Qed.

--- a/reals/fast/CRcos.v
+++ b/reals/fast/CRcos.v
@@ -245,28 +245,57 @@ Qed.
 
 Definition cos (x:CR) := cos_slow (x - (compress (scale (2*Qceiling (approximate (x*(CRinv_pos (6#1) (scale 2 CRpi))) (1#2)%Qpos -(1#2))) CRpi)))%CR.
 
+Lemma  cos_cos_slow : forall x, cos x = cos_slow x.
+Proof.
+  intros.
+  unfold cos.
+  generalize (Qround.Qceiling (approximate (x * CRinv_pos (6 # 1) (scale 2 CRpi))
+   (1 # 2)%Qpos - (1 # 2)))%CR.
+  intros z.
+  rewrite -> compress_correct.
+  rewrite <- (CRasIRasCR_id x).
+  rewrite <- CRpi_correct, <- CRmult_scale, <- IR_inj_Q_as_CR, <- IR_mult_as_CR,
+   <- IR_minus_as_CR, <- cos_slow_correct, <- cos_slow_correct.
+  remember (CRasIR x) as y.
+  clear dependent x. rename y into x.
+  apply IRasCR_wd.
+  rewrite -> inj_Q_mult.
+  change (2:Q) with (Two:Q).
+  rewrite -> inj_Q_nring.
+  symmetry.
+  rstepr (Cos (x[+]([--](inj_Q IR z))[*](Two[*]Pi))).
+  setoid_replace (inj_Q IR z) with (zring z:IR).
+  rewrite <- zring_inv.
+  symmetry; apply Cos_periodic_Z.
+  rewrite <- inj_Q_zring.
+  apply inj_Q_wd.
+  symmetry; apply zring_Q.
+Qed.
+
 Lemma cos_correct : forall x,
   (IRasCR (Cos x) == cos (IRasCR x))%CR.
 Proof.
- intros x.
- unfold cos.
- generalize (Qceiling (approximate (IRasCR x * CRinv_pos (6 # 1) (scale 2 CRpi))
-   (1 # 2)%Qpos - (1 # 2)))%CR.
- intros z.
- rewrite -> compress_correct.
- rewrite <- CRpi_correct, <- CRmult_scale, <- IR_inj_Q_as_CR, <- IR_mult_as_CR,
-   <- IR_minus_as_CR, <- cos_slow_correct.
- apply IRasCR_wd.
- rewrite -> inj_Q_mult.
- change (2:Q) with (Two:Q).
- rewrite -> inj_Q_nring.
- rstepr (Cos (x[+]([--](inj_Q IR z))[*](Two[*]Pi))).
- setoid_replace (inj_Q IR z) with (zring z:IR).
-  rewrite <- zring_inv.
-  symmetry; apply Cos_periodic_Z.
- rewrite <- inj_Q_zring.
- apply inj_Q_wd.
- symmetry; apply zring_Q.
+  intros x.
+  rewrite cos_cos_slow.
+  apply cos_slow_correct.
+Qed.
+
+Instance Setoid_Morphism_cos : Setoid_Morphism cos.
+Proof.
+  constructor; try apply st_isSetoid.
+  intros a b Heq.
+  rewrite cos_cos_slow, cos_cos_slow.
+  rewrite Heq.
+  reflexivity.
+Qed.
+
+
+Lemma cos_correct_CR : forall x,
+  (IRasCR (Cos (CRasIR x)) = cos x).
+Proof.
+  intros x. rewrite cos_correct.
+  apply sm_proper.
+  apply CRasIRasCR_id.
 Qed.
 
 (* begin hide *)

--- a/reals/fast/CRcos.v
+++ b/reals/fast/CRcos.v
@@ -247,7 +247,7 @@ Definition cos (x:CR) := cos_slow (x - (compress (scale (2*Qceiling (approximate
 
 Lemma  cos_cos_slow : forall x, cos x = cos_slow x.
 Proof.
-  intros.
+  intros x.
   unfold cos.
   generalize (Qround.Qceiling (approximate (x * CRinv_pos (6 # 1) (scale 2 CRpi))
    (1 # 2)%Qpos - (1 # 2)))%CR.

--- a/reals/fast/CRcos.v
+++ b/reals/fast/CRcos.v
@@ -301,3 +301,13 @@ Qed.
 (* begin hide *)
 Hint Rewrite cos_correct : IRtoCR.
 (* end hide *)
+
+
+Lemma CRCos_plus_Pi: ∀ x : CR, (cos (x + CRpi) = - (cos x))%CR.
+  intros x.
+  pose proof (Pi.Cos_plus_Pi (CRasIR x)) as Hc.
+  apply IRasCR_wd in Hc.
+  autorewrite with IRtoCR in Hc.
+  rewrite CRasIRasCR_id in Hc.
+  exact Hc.
+Qed.

--- a/reals/fast/CRsin.v
+++ b/reals/fast/CRsin.v
@@ -606,3 +606,13 @@ Qed.
 (* begin hide *)
 Hint Rewrite sin_correct : IRtoCR.
 (* end hide *)
+
+
+Lemma CRSin_plus_Pi: ∀ x : CR, (sin (x + CRpi) = (- sin x))%CR.
+  intros x.
+  pose proof (Pi.Sin_plus_Pi (CRasIR x)) as Hc.
+  apply IRasCR_wd in Hc.
+  autorewrite with IRtoCR in Hc.
+  rewrite CRasIRasCR_id in Hc.
+  exact Hc.
+Qed.

--- a/reals/fast/CRsin.v
+++ b/reals/fast/CRsin.v
@@ -552,7 +552,7 @@ Definition sin (x:CR) := sin_slow (x - (compress (scale (2*Qceiling (approximate
 
 Lemma  sin_sin_slow : forall x, sin x = sin_slow x.
 Proof.
-  intros.
+  intros x.
   unfold sin.
   generalize (Qround.Qceiling (approximate (x * CRinv_pos (6 # 1) (scale 2 CRpi))
    (1 # 2)%Qpos - (1 # 2)))%CR.

--- a/reals/fast/CRsin.v
+++ b/reals/fast/CRsin.v
@@ -550,28 +550,57 @@ Qed.
 
 Definition sin (x:CR) := sin_slow (x - (compress (scale (2*Qceiling (approximate (x*(CRinv_pos (6#1) (scale 2 CRpi))) (1#2)%Qpos -(1#2))) CRpi)))%CR.
 
+Lemma  sin_sin_slow : forall x, sin x = sin_slow x.
+Proof.
+  intros.
+  unfold sin.
+  generalize (Qround.Qceiling (approximate (x * CRinv_pos (6 # 1) (scale 2 CRpi))
+   (1 # 2)%Qpos - (1 # 2)))%CR.
+  intros z.
+  rewrite -> compress_correct.
+  rewrite <- (CRasIRasCR_id x).
+  rewrite <- CRpi_correct, <- CRmult_scale, <- IR_inj_Q_as_CR, <- IR_mult_as_CR,
+   <- IR_minus_as_CR, <- sin_slow_correct, <- sin_slow_correct.
+  remember (CRasIR x) as y.
+  clear dependent x. rename y into x.
+  apply IRasCR_wd.
+  rewrite -> inj_Q_mult.
+  change (2:Q) with (Two:Q).
+  rewrite -> inj_Q_nring.
+  symmetry.
+  rstepr (Sin (x[+]([--](inj_Q IR z))[*](Two[*]Pi))).
+  setoid_replace (inj_Q IR z) with (zring z:IR).
+  rewrite <- zring_inv.
+  symmetry; apply Sin_periodic_Z.
+  rewrite <- inj_Q_zring.
+  apply inj_Q_wd.
+  symmetry; apply zring_Q.
+Qed.
+
 Lemma sin_correct : forall x,
   (IRasCR (Sin x) == sin (IRasCR x))%CR.
 Proof.
- intros x.
- unfold sin.
- generalize (Qceiling (approximate (IRasCR x * CRinv_pos (6 # 1) (scale 2 CRpi))
-   (1 # 2)%Qpos - (1 # 2)))%CR.
- intros z.
- rewrite -> compress_correct.
- rewrite <- CRpi_correct, <- CRmult_scale, <- IR_inj_Q_as_CR, <- IR_mult_as_CR,
-   <- IR_minus_as_CR, <- sin_slow_correct.
- apply IRasCR_wd.
- rewrite -> inj_Q_mult.
- change (2:Q) with (Two:Q).
- rewrite -> inj_Q_nring.
- rstepr (Sin (x[+]([--](inj_Q IR z))[*](Two[*]Pi))).
- setoid_replace (inj_Q IR z) with (zring z:IR).
-  rewrite <- zring_inv.
-  symmetry; apply Sin_periodic_Z.
- rewrite <- inj_Q_zring.
- apply inj_Q_wd.
- symmetry; apply zring_Q.
+  intros x.
+  rewrite sin_sin_slow.
+  apply sin_slow_correct.
+Qed.
+
+
+Instance Setoid_Morphism_sin : Setoid_Morphism sin.
+Proof.
+  constructor; try apply st_isSetoid.
+  intros a b Heq.
+  rewrite sin_sin_slow, sin_sin_slow.
+  rewrite Heq.
+  reflexivity.
+Qed.
+
+Lemma sin_correct_CR : forall x,
+  (IRasCR (Sin (CRasIR x)) = sin x).
+Proof.
+  intros x. rewrite sin_correct.
+  apply sm_proper.
+  apply CRasIRasCR_id.
 Qed.
 
 (* begin hide *)

--- a/transc/MoreArcTan.v
+++ b/transc/MoreArcTan.v
@@ -31,6 +31,117 @@ Proof.
  apply ArcTan_range.
 Qed.
 
+Require Import Coq.Unicode.Utf8.
+
+Local Opaque Sine  Cosine.
+
+Lemma DomTangCosNZ : forall θ,
+    Dom Tang θ IFF Dom (f_rcpcl' IR) (Cos θ).
+Proof.
+  unfold Tang. simpl.
+  Local Transparent Sine.
+  simpl. unfold extend, conjP. intros. simpl.
+  Local Transparent Cosine.
+  split; intro H; 
+    [destruct H as [? H]; destruct H as [H Hc]| split;[|split]];
+    try tauto; try apply Hc.
+- simpl. auto.
+- intros. eapply ap_wd; eauto;[| reflexivity].
+  apply pfwdef. reflexivity.
+Qed.
+
+Local Opaque Sine  Cosine.
+Lemma DomTangCosSqNZ : forall θ,
+    Dom Tang θ IFF Dom (f_rcpcl' IR) ((Cos θ)[^]2).
+Proof.
+  unfold Tang. simpl.
+  Local Transparent Sine.
+  simpl. unfold extend, conjP. intros. simpl.
+  Local Transparent Cosine.
+  split; intro H; 
+    [destruct H as [? H]; destruct H as [H Hc]| split;[|split]];
+    try tauto; try apply Hc.
+- specialize (Hc I). 
+  pose proof (mult_resp_ap_zero _ _ _  Hc Hc) as Hx.
+  eapply ap_wd; eauto;[| reflexivity].
+  rational.
+- simpl. auto.
+- intros. apply mult_cancel_ap_zero_rht in H.
+  eapply ap_wd; eauto;[| reflexivity].
+  apply pfwdef. reflexivity.
+Qed.
+
+Lemma cr_div_shiftr :
+  forall {F: CField} (x y z : F) zp,
+  z [#] [0]
+  -> (x [*] z [=] y <-> x [=] (y [/] z [//] zp)).
+Proof.
+  intros ? ? ? ? ? Hzp. split; intros Hm.
+- apply mult_cancel_rht with (z:= z) ; trivial.
+  rewrite div_1.
+  trivial.
+- apply mult_wdl with (y:=z) in Hm.
+  rewrite div_1 in Hm.
+  trivial.
+Qed.
+
+  
+Lemma CosSqrFromTan1 : forall θ Hx H, 
+    Cos θ[^]2 [=] ([1][/] ([1][+]Tan θ Hx[^]2)[//]H).
+Proof.
+  intros.
+  pose proof (DomTangCosSqNZ θ) as Hd.
+  apply fst in Hd. specialize (Hd Hx).
+  pose proof (FFT' θ Hx Hd) as Hf.
+  apply cr_div_shiftr; eauto;[].
+  apply cr_div_shiftr in Hf; eauto;[].
+  rewrite mult_commutes. trivial.
+Qed.
+
+Lemma CosOfArcTan : forall r H,
+    Cos (ArcTan r)[^]2 [=] ([1][/] ([1][+]r[^]2)[//]H).
+Proof.
+  intros.
+  rewrite CosSqrFromTan1.
+  apply cr_div_shiftr; eauto;[].
+  symmetry.
+  rewrite mult_commutes.
+  rewrite x_mult_y_div_z.
+  apply cr_div_shiftr; eauto;
+  [|rewrite <- Tan_ArcTan; rational; fail].
+  eauto using 
+    zero_minus_apart,
+    ap_wdl_unfolded,
+    zexp_resp_ap_zero,
+    zexp_one.
+  Grab Existential Variables.
+- simpl. simpl in H. eapply ap_wd; eauto;[| reflexivity].
+  rewrite <- Tan_ArcTan; rational.
+- simpl. simpl in H. eapply ap_wd; eauto;[| reflexivity].
+  rewrite <- Tan_ArcTan; rational.
+- apply Dom_Tang_ArcTan.
+Qed.
+
+
+Lemma SinOfArcTan : forall r H,
+    Sin (ArcTan r)[^]2 [=] (r[^]2[/] ([1][+]r[^]2)[//]H).
+Proof.
+  intros.
+  pose proof (CosOfArcTan r H) as Hc.
+  pose proof (FFT (ArcTan r)) as Hf.
+  pose proof (cg_minus_wd _ _ _ _ _ Hf Hc) as Hm.
+  clear Hf Hc.
+  match goal with
+  [H:st_eq ?l _ |- st_eq ?lg _] => assert (l [=] lg) as Heq
+      by (rational); rewrite Heq in Hm; clear Heq
+  end.
+  rewrite Hm.
+  apply cr_div_shiftr; eauto.
+  rewrite ring_distr2.
+  rewrite div_1.
+  rational.
+Qed.
+
 Lemma ArcTan_zero : ArcTan [0][=][0].
 Proof.
  assert (Z:Dom Tang [0]).

--- a/transc/MoreArcTan.v
+++ b/transc/MoreArcTan.v
@@ -142,6 +142,38 @@ Proof.
   rational.
 Qed.
 
+Lemma plus_resp_nonnegR_pos
+   : ∀ (R : COrdField) (x y : R), 
+      [0][<=]x → [0][<]y → [0][<]y[+]x.
+Proof.
+  intros.
+  eapply less_wdr;[| apply cag_commutes_unfolded].
+  apply plus_resp_nonneg_pos; trivial.
+Qed.
+
+Lemma  OneplusRSqrApart0 : 
+   ∀ (R : COrdField) (r:R), ([1][+]r[^]2)[#][0].
+Proof.
+  intros R r.
+  apply Greater_imp_ap.
+  apply plus_resp_nonnegR_pos;[|apply pos_one].
+  apply sqr_nonneg.
+Qed.
+
+Lemma CosOfArcTan2 : forall r,
+  Cos (ArcTan r)[^]2 
+  [=] ([1][/] ([1][+]r[^]2)[//] (OneplusRSqrApart0 _ _)).
+Proof.
+  intros. apply  CosOfArcTan.
+Qed.
+
+Lemma SinOfArcTan2 : forall r,
+  Sin (ArcTan r)[^]2 
+  [=] (r[^]2[/] ([1][+]r[^]2)[//] (OneplusRSqrApart0 _ _)).
+Proof.
+  intros. apply SinOfArcTan.
+Qed.
+
 Lemma ArcTan_zero : ArcTan [0][=][0].
 Proof.
  assert (Z:Dom Tang [0]).


### PR DESCRIPTION
1) new lemmas about Cos and Sin of ArcTan (IR) in tranc.MoreArcTan
2) many lemmas about arctan, CRcos and CRsin (in CoRN.reals.fast.CRSinCos). Most of them are analogs of existing lemmas about IR versions.
3) Using typeclasses, added unicode notations for π and ½ in CoRN.reals.fast.CRSinCos. Should this be moved to MatchClasses.interfaces.canonical_names ?