### PR TITLE
minimal patch to compile CoRN on Mac and Win following recent MathClasses patch

### DIFF
--- a/metric2/DistanceMetricSpace.v
+++ b/metric2/DistanceMetricSpace.v
@@ -3,7 +3,7 @@ Require NNUpperR.
 Import NNUpperR.notations.
 Import QnonNeg.notations.
 
-Require Import Metric.
+Require Import CoRN.metric2.Metric.
 
 Open Scope NNUpperR_scope.
 

--- a/metric2/Hausdorff.v
+++ b/metric2/Hausdorff.v
@@ -20,9 +20,9 @@ CONNECTION WITH THE PROOF OR THE USE OR OTHER DEALINGS IN THE PROOF.
 *)
 Require Import ZBasics.
 Require Import Classic.
-Require Export Metric.
+Require Export CoRN.metric2.Metric.
 Require Import Classification.
-Require Import List.
+Require Import Coq.Lists.List.
 Require Import ZArith.
 Require Import QMinMax.
 Require Import QposMinMax.

--- a/metric2/Limit.v
+++ b/metric2/Limit.v
@@ -20,9 +20,9 @@ CONNECTION WITH THE PROOF OR THE USE OR OTHER DEALINGS IN THE PROOF.
 *)
 
 Require Import QArith.
-Require Import Bool.
+Require Import Coq.Bool.Bool.
 Require Export Complete.
-Require Export Streams.
+Require Export Coq.Lists.Streams.
 Require Import abstract_algebra theory.streams orders.naturals.
 
 (**

--- a/metric2/UCFnMonoid.v
+++ b/metric2/UCFnMonoid.v
@@ -1,4 +1,4 @@
-Require Import Utf8 Streams UniformContinuity abstract_algebra.
+Require Import Utf8 Coq.Lists.Streams UniformContinuity abstract_algebra.
 
 
 (** Uniform continuous maps from a metric space to itself (endomaps)

--- a/model/structures/NNUpperR.v
+++ b/model/structures/NNUpperR.v
@@ -1,7 +1,7 @@
 (* This module is designed to *not* be Import'ed, only Require'd. *)
 
 Require Import
-  Qabs Qordfield Qpossec Qminmax Ring Program.
+  Qabs Qordfield Qpossec Coq.QArith.Qminmax Ring Program.
 
 Require QnonNeg.
 Import QnonNeg.notations.

--- a/model/structures/QnonNeg.v
+++ b/model/structures/QnonNeg.v
@@ -1,6 +1,6 @@
 (* This module is designed to *not* be Import'ed, only Require'd. *)
 
-Require Import Program Qpossec QposInf Qminmax.
+Require Import Program Qpossec QposInf Coq.QArith.Qminmax.
 
 Set Automatic Introduction.
 

--- a/model/structures/StepQsec.v
+++ b/model/structures/StepQsec.v
@@ -2,7 +2,7 @@ Require Import Qmetric.
 Require Export QArith.
 Require Export StepFunctionSetoid.
 Require Import Qabs.
-Require Import Bool.
+Require Import Coq.Bool.Bool.
 Require Import CornTac.
 Require Import CornBasics.
 Require Import RSetoid.

--- a/reals/fast/CRAlternatingSum.v
+++ b/reals/fast/CRAlternatingSum.v
@@ -24,7 +24,7 @@ Require Import Q_in_CReals.
 Require Import ArithRing.
 Require Export CRArith.
 Require Import CRIR.
-Require Import Bool.
+Require Import Coq.Bool.Bool.
 Require Import COrdAbs.
 Require Import Qordfield.
 Require Export Qmetric.
@@ -32,7 +32,7 @@ Require Import LazyNat.
 Require Export Limit.
 Require Import QposMinMax.
 Require Import Qpower.
-Require Export Streams.
+Require Export Coq.Lists.Streams.
 Require Import PowerSeries.
 Require Import CornTac.
 Require Import Qclasses.

--- a/tactics/AlgReflection.v
+++ b/tactics/AlgReflection.v
@@ -36,7 +36,7 @@
 
 (* begin hide *)
 Require Export CLogic.
-Require Export Bool.
+Require Export Coq.Bool.Bool.
 
 Section Syntactic_Expressions.
 

--- a/tactics/csetoid_rewrite.v
+++ b/tactics/csetoid_rewrite.v
@@ -1305,7 +1305,7 @@ Ltac partial_setoid_replace_cxt x y h :=
 
 (*End partial_csetoid_rewrite.*)
 
-Require Export Bool.
+Require Export Coq.Bool.Bool.
 
 Ltac term_cont_part t :=
   match constr:t with


### PR DESCRIPTION
Manual CoRN patch on Mac and Win for case-sensitive file systems (after automated MathClasses case-sensitive file systems patch https://github.com/math-classes/math-classes/commit/9330ab1133da24bcd2deee9e26ae27988b13c63a). Verified on Mac, Win, Ubuntu Linux with Coq 8.4pl6 (via opam on Mac, Linux, via installer Windows), and latest MathClasses in user-contrib (again via opam on Mac, Linux, manually placed there on Win). Note if math-classes directory is placed INSIDE project then another 18 files need changes for complete import paths, hence a comprehensive fix similar to MathClasses fix of Jason Gross (https://gist.github.com/JasonGross/14decf638535a2447286) may be best. 

Windows requires one additional but separate fix for reals/faster/ARAlternatingSum.v (reduce parameter 50000 to 5000 for vm_compute); not a part of this commit but can provide it.

One other recent CoRN change for ode/Picard.v is broken on ALL three platforms (again not part of this commit, just to bring it to your attention as have no insight into that code). Issue is the second native Compute line which should either be commented or also changed to vm_compute like first one (works fine after commenting this line).
