### PR TITLE
corn : switch to the external Bignums library

### DIFF
--- a/reals/faster/ARbigD.v
+++ b/reals/faster/ARbigD.v
@@ -1,5 +1,5 @@
 Require Import
-  Coq.Program.Program Coq.QArith.QArith Coq.ZArith.ZArith Coq.Numbers.Integer.BigZ.BigZ CoRN.model.structures.Qpossec
+  Coq.Program.Program Coq.QArith.QArith Coq.ZArith.ZArith Bignums.BigZ.BigZ CoRN.model.structures.Qpossec
   CoRN.metric2.MetricMorphisms CoRN.model.metric2.Qmetric CoRN.util.Qdlog CoRN.reals.faster.ARArith
   MathClasses.theory.int_pow MathClasses.theory.nat_pow
   MathClasses.implementations.stdlib_rationals MathClasses.implementations.stdlib_binary_integers MathClasses.implementations.fast_integers MathClasses.implementations.dyadics.

--- a/reals/faster/ARbigQ.v
+++ b/reals/faster/ARbigQ.v
@@ -1,5 +1,5 @@
 Require Import
-  Coq.Program.Program Coq.QArith.QArith Coq.ZArith.ZArith Coq.Numbers.Integer.BigZ.BigZ Coq.Numbers.Rational.BigQ.BigQ CoRN.model.structures.Qpossec
+  Coq.Program.Program Coq.QArith.QArith Coq.ZArith.ZArith Bignums.BigZ.BigZ Bignums.BigQ.BigQ CoRN.model.structures.Qpossec
   CoRN.reals.fast.Compress CoRN.reals.faster.ARQ
   CoRN.metric2.MetricMorphisms CoRN.model.metric2.Qmetric CoRN.reals.faster.ARArith
   MathClasses.implementations.stdlib_rationals MathClasses.implementations.stdlib_binary_integers MathClasses.implementations.field_of_fractions


### PR DESCRIPTION
In prevision for Coq 8.7, where the bignums library is going to be an external package, you might want to push the following commit in a v8.7 branch of CoRN. See [PR #498](https://github.com/coq/coq/pull/498)

The external bignum package is already available this way (an opam package is underway) :
```
 git clone https://github.com/coq/bignums.git && cd bignums && make && make install
```
The above command is for the trunk-compatible version of bignum, there is also a v8.6 branch there.