### PR TITLE
Fix obsolete vernacular syntax for locality.

### DIFF
--- a/algebra/CPoly_Newton.v
+++ b/algebra/CPoly_Newton.v
@@ -46,7 +46,7 @@ Admitted.
   (** Todo: Prove and move. Only added here temporarily to make definition of repeated integral compile. *)
 
 
-Open Local Scope CR_scope.
+Local Open Scope CR_scope.
 
 Local Notation Σ := cm_Sum.
 Local Notation Π := cr_Product.

--- a/algebra/RSetoid.v
+++ b/algebra/RSetoid.v
@@ -79,7 +79,7 @@ Defined.
 
 Notation "x --> y" := (extSetoid x y) (at level 55, right associativity) : setoid_scope.
 
-Open Local Scope setoid_scope.
+Local Open Scope setoid_scope.
 (**
 ** Basic Combinators for Setoids
 *)

--- a/broken/CCayleyHamilton.v
+++ b/broken/CCayleyHamilton.v
@@ -147,9 +147,9 @@ Open Scope matrix_scope.
 Section char_poly.
 
 Variable n : nat.
-Notation Local "R [ 'X' ]" := (cpoly_cring R)
+Local Notation "R [ 'X' ]" := (cpoly_cring R)
   (at level 0, format "R [ 'X' ]").
-Notation Local "'M' ( R )" := (matrix R n n)
+Local Notation "'M' ( R )" := (matrix R n n)
   (at level 0, format "'M' ( R )").
 
 Variable A : M(CR).

--- a/broken/CPoly_Lagrange.v
+++ b/broken/CPoly_Lagrange.v
@@ -8,7 +8,7 @@ Require Import
 Require ne_list.
 Import ne_list.notations.
 
-Open Local Scope CR_scope.
+Local Open Scope CR_scope.
 
 Local Notation Σ := cm_Sum.
 Local Notation Π := cr_Product.

--- a/broken/DivDiff_RepeatedIntegral.v
+++ b/broken/DivDiff_RepeatedIntegral.v
@@ -157,7 +157,7 @@ Proof. induction xs; simpl; congruence. Qed.
 
     Definition G (n: nat): Type := UCFunction (SomeWeights n) (sig ((∈ nth_deriv_bound))).
 
-Open Local Scope CR_scope.
+Local Open Scope CR_scope.
 
     Section reduce.
 

--- a/broken/NewAbstractIntegration.v
+++ b/broken/NewAbstractIntegration.v
@@ -15,9 +15,9 @@ Import QnonNeg.notations QnnInf.notations CRball.notations.
 
 Implicit Arguments proj1_sig [[A] [P]].
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
-Open Local Scope CR_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
+Local Open Scope CR_scope.
 
 Hint Immediate ball_refl Qle_refl.
 

--- a/broken/algebra/bigopsClass.v
+++ b/broken/algebra/bigopsClass.v
@@ -435,9 +435,9 @@ Context {op_assoc : associative op}.
 Context {op_left_id : left_unit op idm}.
 Context {op_right_id : right_unit op idm}.
 
-Notation Local "*%M" := op (at level 0).
-Notation Local "x * y" := (op x y).
-Notation Local "1" := idm.
+Local Notation "*%M" := op (at level 0).
+Local Notation "x * y" := (op x y).
+Local Notation "1" := idm.
 
 Lemma eq_big_idx_seq : forall idx' I r (P : pred I) F,
      right_unit *%M idx' -> has P r ->
@@ -581,9 +581,9 @@ Context {op_left_id : left_unit op idm}.
 Context {op_right_id : right_unit op idm}.
 Context {op_comm : commutative op}.
 
-Notation Local "'*%M'" := op (at level 0).
-Notation Local "x * y" := (op x y).
-Notation Local "1" := idm.
+Local Notation "'*%M'" := op (at level 0).
+Local Notation "x * y" := (op x y).
+Local Notation "1" := idm.
 
 (* sinon ca marche pas... *)
 Existing Instance mulAC_comm_l.
@@ -874,11 +874,11 @@ End Morphism.
 Section Distributivity.
 
 Context `{Equivalence} {add mul : binop A} {zero : A}.
-Notation Local "*%M" := mul (at level 0).
-Notation Local "x * y" := (mul x y).
-Notation Local "0" := zero.
-Notation Local "+%M" := add (at level 0).
-Notation Local "x + y" := (add x y).
+Local Notation "*%M" := mul (at level 0).
+Local Notation "x * y" := (mul x y).
+Local Notation "0" := zero.
+Local Notation "+%M" := add (at level 0).
+Local Notation "x + y" := (add x y).
 
 Context {op_morph : Proper (Equivalence.equiv==>Equivalence.equiv==>Equivalence.equiv) add}.
 Context {mul_morph : Proper (Equivalence.equiv==>Equivalence.equiv==>Equivalence.equiv) mul}.
@@ -907,7 +907,7 @@ by apply op_right_zero.
 Qed.
 
 Context {one : R}.
-Notation Local "1" := one.
+Local Notation "1" := one.
 
 (* sinon ça marche pas...*)
 Existing Instance mulC_id_l.

--- a/broken/matrixClass.v
+++ b/broken/matrixClass.v
@@ -60,7 +60,7 @@ Reserved Notation "\adj A"  (at level 10, A at level 8, format "\adj  A").
 
 Delimit Scope matrix_scope with M.
 
-Open Local Scope matrix_scope.
+Local Open Scope matrix_scope.
 
 Definition setoid_cancel {A : Type} {B : Type} `{Equivalence A aeq} (f : A -> B) g :=
     forall x, g (f x) === x.

--- a/examples/Circle.v
+++ b/examples/Circle.v
@@ -15,7 +15,7 @@ Qed.
 
 Definition stableR2:=(stableComplete Q2 stableQ2).
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Require Import metric2.Classified.
 
@@ -32,7 +32,7 @@ Definition diag:X-->(ProductMS X X):=Build_UniformlyContinuousFunction diag_uc.
 End diag.
 
 Require Import Interval.
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Section PathImage.
 Variable path:Q-->R2.

--- a/examples/PlotExamples.v
+++ b/examples/PlotExamples.v
@@ -26,9 +26,9 @@ Require Import CRtrans.
 Notation star := (@refl_equal _ Lt).
 Notation "∗" := star.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
-Open Local Scope raster.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
+Local Open Scope raster.
 
 (* This file illustrates how to plot funcitons *)
 (* PlotQ requires that we plot uniformly continuous functions.

--- a/examples/RealFast.v
+++ b/examples/RealFast.v
@@ -20,7 +20,7 @@ CONNECTION WITH THE PROOF OR THE USE OR OTHER DEALINGS IN THE PROOF.
 *)
 Require Import CRtrans.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (* This file illustrates how to use the computational reals CR *)
 

--- a/logic/Stability.v
+++ b/logic/Stability.v
@@ -130,7 +130,7 @@ Proof.
   auto using decision_stable, Qle_dec.
 Qed.
 
-Open Local Scope CR_scope.
+Local Open Scope CR_scope.
 
 Lemma DN_or P Q: Not ((Not P) /\ (Not Q)) -> DN (P + Q).
 Proof. firstorder. Qed.

--- a/metric2/Classification.v
+++ b/metric2/Classification.v
@@ -21,7 +21,7 @@ CONNECTION WITH THE PROOF OR THE USE OR OTHER DEALINGS IN THE PROOF.
 Require Export CoRN.metric2.Metric.
 Require Import CoRN.tactics.Qauto.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (**
 ** Classification of metric spaces

--- a/metric2/Compact.v
+++ b/metric2/Compact.v
@@ -32,7 +32,7 @@ Require Import CoRN.tactics.CornTac.
 Set Implicit Arguments.
 Set Automatic Introduction.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (**
 * Compact sets
@@ -1445,7 +1445,7 @@ Proof.
  apply: orWeaken; right; auto.
 Qed.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Definition FinCompact : FinEnum stableCX --> Compact stableX :=
  Build_UniformlyContinuousFunction FinCompact_uc.
@@ -1662,7 +1662,7 @@ Hypothesis stableY : stableMetric Y.
 Hypothesis plX : PrelengthSpace X.
 Hypothesis plFEX : PrelengthSpace (FinEnum stableX).
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Variable f : X --> Y.
 
@@ -1760,7 +1760,7 @@ Hypothesis stableY : stableMetric Y.
 Hypothesis plX : PrelengthSpace X.
 Hypothesis plFEX : PrelengthSpace (FinEnum stableX).
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Variable f : X --> Complete Y.
 

--- a/metric2/Complete.v
+++ b/metric2/Complete.v
@@ -31,8 +31,8 @@ Require Import CoRN.tactics.CornTac.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 (**
 ** Complete metric space
 *)

--- a/metric2/CompleteProduct.v
+++ b/metric2/CompleteProduct.v
@@ -40,7 +40,7 @@ Proof.
  assumption.
 Qed.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Definition pi1 : XY --> X :=
 Build_UniformlyContinuousFunction fst_uc.

--- a/metric2/FinEnum.v
+++ b/metric2/FinEnum.v
@@ -30,7 +30,7 @@ Require Import CoRN.tactics.CornTac.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Section Finite.
 
@@ -596,7 +596,7 @@ Proof.
  contradiction.
 Qed.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 (** [map] is compatable with classical in *)
 Lemma InFinEnumC_map : forall (X Y:MetricSpace) (f:X --> Y) a l, InFinEnumC a l -> InFinEnumC (f a) (map f l).

--- a/metric2/Graph.v
+++ b/metric2/Graph.v
@@ -30,7 +30,7 @@ Require Import CoRN.tactics.CornTac.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Section Graph.
 (**
@@ -47,7 +47,7 @@ Let XY := ProductMS X Y.
 various ways to produce a graph *)
 Definition graphPoint_raw (f:X -> Y) (x:X) : XY := (x,f x).
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Variable f : X --> Y.
 
@@ -296,7 +296,7 @@ Let XY := ProductMS X Y.
 
 Definition graphPoint_b_raw (f:X -> Complete Y) (x:X) : Complete XY := Couple (Cunit x,f x).
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Variable f : X --> Complete Y.
 

--- a/metric2/Hausdorff.v
+++ b/metric2/Hausdorff.v
@@ -29,7 +29,7 @@ Require Import CoRN.model.totalorder.QposMinMax.
 Require Import CoRN.tactics.Qauto.
 Require Import CoRN.tactics.CornTac.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Section HausdorffMetric.
 

--- a/metric2/Limit.v
+++ b/metric2/Limit.v
@@ -95,7 +95,7 @@ Fixpoint LazyExists_inc `{P : Stream A → Prop}
 
 Section TakeUntil.
 (* begin hide *)
-Coercion Local Is_true : bool >-> Sortclass.
+Local Coercion Is_true : bool >-> Sortclass.
 (* end hide *)
 (** takeUntil creates a list of of elements upto a the point where the predicate
 P is satisfied.  For efficency reasons it doesn't actually build a list, but

--- a/metric2/Metric.v
+++ b/metric2/Metric.v
@@ -32,7 +32,7 @@ Require Import CoRN.stdlib_omissions.Q.
 Require CoRN.model.structures.QnnInf.
 Import QnnInf.notations.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Set Implicit Arguments.
 

--- a/metric2/MetricMorphisms.v
+++ b/metric2/MetricMorphisms.v
@@ -7,7 +7,7 @@ Require Import
   CoRN.metric2.Complete CoRN.metric2.Prelength
   MathClasses.interfaces.abstract_algebra.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 (* Given an embedding of a setoid [X] into a metric space [Y] then [X] is also a 
    metric space. Moreover this embedding is uniformly continuous. *)

--- a/metric2/Prelength.v
+++ b/metric2/Prelength.v
@@ -33,7 +33,7 @@ Require Import CoRN.tactics.Qauto.
 Set Implicit Arguments.
 Set Automatic Introduction.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Section Prelength_Space.
 (**
@@ -275,7 +275,7 @@ End Prelength_Space.
 
 Section Map.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 Variable X Y : MetricSpace.
 Hypothesis plX : PrelengthSpace X.
 Variable f : X --> Y.
@@ -350,7 +350,7 @@ Qed.
 End Map.
 
 Section fast_Monad_Laws.
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Variable X Y Z : MetricSpace.
 Hypothesis plX : PrelengthSpace X.
@@ -371,7 +371,7 @@ Proof. rewrite Cmap_correct. simpl. apply MonadLaw3. Qed.
 
 End fast_Monad_Laws.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 (** [Cmap] preserves extensional equality *)
 

--- a/metric2/ProductMetric.v
+++ b/metric2/ProductMetric.v
@@ -201,7 +201,7 @@ Proof.
  split; assumption.
 Qed.
 (* end hide *)
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 (** [together] forms the tensor of two functions operating between
 metric spaces *)

--- a/metric2/StepFunction.v
+++ b/metric2/StepFunction.v
@@ -26,7 +26,7 @@ Require Import CoRN.algebra.COrdFields.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Section StepFunction.
 
@@ -602,7 +602,7 @@ Defined.
 
 Notation "f ^@> x" := (Map f x) (at level 15, left associativity) : sfscope.
 
-Open Local Scope sfscope.
+Local Open Scope sfscope.
 (** Step functions are an applicative functor *)
 Fixpoint Ap (X Y:Type) (f:StepF (X->Y)) (a:StepF X) : StepF Y :=
 match f with

--- a/metric2/StepFunctionMonad.v
+++ b/metric2/StepFunctionMonad.v
@@ -40,8 +40,8 @@ Proof.
  apply StepF_Sth.
 Defined.
 
-Open Local Scope setoid_scope.
-Open Local Scope sfstscope.
+Local Open Scope setoid_scope.
+Local Open Scope sfstscope.
 
 (** We redefine several functions to return a setoid type. *)
 

--- a/metric2/StepFunctionSetoid.v
+++ b/metric2/StepFunctionSetoid.v
@@ -29,7 +29,7 @@ Require Import CoRN.algebra.COrdFields.
 Set Implicit Arguments.
 Set Automatic Introduction.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Section StepF_Functions.
 
@@ -70,7 +70,7 @@ End StepF_Functions.
 (* begin hide *)
 Implicit Arguments constStepF [X].
 (* end hide *)
-Open Local Scope setoid_scope.
+Local Open Scope setoid_scope.
 
 (** We lift ap to the setoid version.  Map is a notation calling ap so
 that all lemmas about ap automatically apply to ap *)
@@ -79,7 +79,7 @@ Notation "f <@> x" := (Ap f x) (at level 15, left associativity) : sfstscope.
 Notation "f ^@> x" := (Ap (constStepF f) x) (at level 15, left associativity) : sfstscope.
 Notation "f <@^ x" := (Ap f (constStepF x)) (at level 15, left associativity) : sfstscope.
 
-Open Local Scope sfstscope.
+Local Open Scope sfstscope.
 
 (** We lift lemmas about map, ap, mirror, and glue *)
 Lemma MirrorGlue : forall (X : RSetoid) (o : OpenUnit) (al ar : StepF X),

--- a/metric2/UniformContinuity.v
+++ b/metric2/UniformContinuity.v
@@ -205,7 +205,7 @@ Build_MetricSpace (@ucBall_wd X Y) (@uc_is_MetricSpace X Y).
 
 Notation "x --> y" := (UniformlyContinuousSpace x y) (at level 55, right associativity) : uc_scope.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 (* begin hide *)
 Add Parametric Morphism (X Y:MetricSpace) f : (@ucFun X Y f) with signature (@st_eq X) ==> (@st_eq Y) as uc_wd.
 Proof.

--- a/model/abgroups/CRabgroup.v
+++ b/model/abgroups/CRabgroup.v
@@ -28,7 +28,7 @@ Require Import CoRN.tactics.CornTac.
 ** Example of a abelian group: $\langle$#&lang;#[CR],[+]$\rangle$#&rang;#
 *)
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Lemma CRisCAbGroup : is_CAbGroup CRasCGroup.
 Proof.

--- a/model/fields/CRfield.v
+++ b/model/fields/CRfield.v
@@ -29,7 +29,7 @@ Require Import CoRN.tactics.CornTac.
 ** Example of a field: $\langle$#&lang;#[CR],[+],[*]$\rangle$#&rang;#
 *)
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Lemma CRisCField : is_CField CRasCRing CRinvT.
 Proof.

--- a/model/groups/CRgroup.v
+++ b/model/groups/CRgroup.v
@@ -28,7 +28,7 @@ Require Import CoRN.tactics.CornTac.
 ** Example of a group: $\langle$#&lang;#[CR],[+]$\rangle$#&rang;#
 *)
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Lemma CRopp_strext : un_op_strext CRasCSetoid CRopp.
 Proof.

--- a/model/lattice/CRlattice.v
+++ b/model/lattice/CRlattice.v
@@ -34,7 +34,7 @@ Section CRLattice.
 
 Let CRlat := CRLattice.
 
-Open Local Scope CR_scope.
+Local Open Scope CR_scope.
 
 Definition CRmin_comm : forall x y : CR, CRmin x y == CRmin y x := @meet_comm CRlat.
 Definition CRmin_assoc : forall x y z : CR, CRmin x (CRmin y z) == CRmin (CRmin x y) z:=

--- a/model/metric2/BoundedFunction.v
+++ b/model/metric2/BoundedFunction.v
@@ -27,7 +27,7 @@ Require Import CoRN.tactics.CornTac.
 
 Set Implicit Arguments.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 (**
 ** Example of a Complete Metric Space: BoundedFunction
 *)

--- a/model/metric2/CRmetric.v
+++ b/model/metric2/CRmetric.v
@@ -28,7 +28,7 @@ Require Import MathClasses.implementations.stdlib_rationals.
 
 Set Implicit Arguments.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 (**
 * Complete Metric Space: Computable Reals (CR)

--- a/model/metric2/IntegrableFunction.v
+++ b/model/metric2/IntegrableFunction.v
@@ -29,7 +29,7 @@ Require Import CoRN.model.metric2.BoundedFunction.
 
 Set Implicit Arguments.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 (**
 ** Example of a Complete Metric Space: IntegrableFunction
 *)

--- a/model/metric2/L1metric.v
+++ b/model/metric2/L1metric.v
@@ -32,9 +32,9 @@ Require Import CoRN.tactics.CornTac.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
-Open Local Scope sfstscope.
-Open Local Scope StepQ_scope.
+Local Open Scope Q_scope.
+Local Open Scope sfstscope.
+Local Open Scope StepQ_scope.
 
 Opaque Qred.
 
@@ -532,7 +532,7 @@ Proof.
  assumption.
 Qed.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Definition IntegralQ_uc : L1StepQ --> Q_as_MetricSpace
 := Build_UniformlyContinuousFunction integral_uc_prf.

--- a/model/metric2/LinfDistMonad.v
+++ b/model/metric2/LinfDistMonad.v
@@ -34,13 +34,13 @@ swap (which we call dist) as in Jones, Duponcheel - composing monads
 *)
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
-Open Local Scope sfstscope.
+Local Open Scope Q_scope.
+Local Open Scope sfstscope.
 
 Section Dist.
 (* M= Complete, N= StepF
 dist = distribComplete*)
-Open Local Scope sfstscope.
+Local Open Scope sfstscope.
 Variable X: MetricSpace.
 (** The dist function exchanges StepF (under the infinity metric) and Complete monads *)
 
@@ -122,9 +122,9 @@ Proof.
  split; revert d1 d2; tauto.
 Qed.
 
-Open Local Scope uc_scope.
-Open Local Scope sfstscope.
-Open Local Scope sfscope.
+Local Open Scope uc_scope.
+Local Open Scope sfstscope.
+Local Open Scope sfscope.
 
 Definition dist: (StepFSup (Complete X))-->(Complete (StepFSup X)).
 Proof.

--- a/model/metric2/LinfMetric.v
+++ b/model/metric2/LinfMetric.v
@@ -34,8 +34,8 @@ Require Import CoRN.tactics.CornTac.
 
 Set Implicit Arguments.
 
-Open Local Scope sfstscope.
-Open Local Scope StepQ_scope.
+Local Open Scope sfstscope.
+Local Open Scope StepQ_scope.
 
 Opaque Qmax Qabs.
 
@@ -160,7 +160,7 @@ Proof.
        apply: plus_resp_leEq_lft; simpl; auto with * ).
 Qed.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Definition StepQSup_uc : LinfStepQ --> Q_as_MetricSpace
 := Build_UniformlyContinuousFunction sup_uc_prf.

--- a/model/metric2/LinfMetricMonad.v
+++ b/model/metric2/LinfMetricMonad.v
@@ -37,8 +37,8 @@ Require Import CoRN.tactics.CornTac.
 Set Implicit Arguments.
 Set Automatic Introduction.
 
-Open Local Scope sfstscope.
-Open Local Scope setoid_scope.
+Local Open Scope sfstscope.
+Local Open Scope setoid_scope.
 
 (**
 ** Linf metric for Step Functions
@@ -292,7 +292,7 @@ Proof.
   assumption. rewrite SplitRGlue;reflexivity.
 Qed.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Section UniformlyContinuousFunctions.
 

--- a/model/metric2/Qmetric.v
+++ b/model/metric2/Qmetric.v
@@ -31,7 +31,7 @@ Require Import CoRN.metric2.UniformContinuity.
 Set Implicit Arguments.
 Set Automatic Introduction.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Opaque Qabs.
 

--- a/model/monoids/CRmonoid.v
+++ b/model/monoids/CRmonoid.v
@@ -24,7 +24,7 @@ Require Export CoRN.model.semigroups.CRsemigroup.
 Require Import CoRN.reals.fast.CRcorrect.
 Require Import CoRN.tactics.CornTac.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 (**
 ** Examples of monoids: $\langle$#&lang;#[CR],[+]$\rangle$#&rang;#

--- a/model/monoids/Qmonoid.v
+++ b/model/monoids/Qmonoid.v
@@ -38,7 +38,7 @@
 Require Export CoRN.model.semigroups.Qsemigroup.
 Require Import CoRN.algebra.CMonoids.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (**
 ** Examples of a monoid: $\langle$#&lang;#[Q],[[+]]$\rangle$#&rang;# and $\langle$#&lang;#[Q],[[*]]$\rangle$#&rang;#

--- a/model/ordfields/CRordfield.v
+++ b/model/ordfields/CRordfield.v
@@ -25,7 +25,7 @@ Require Export CoRN.algebra.COrdFields.
 Require Import CoRN.reals.fast.CRcorrect.
 Require Import CoRN.tactics.CornTac.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Lemma CRlt_strext : Crel_strext CRasCField CRltT.
 Proof.

--- a/model/reals/CRreal.v
+++ b/model/reals/CRreal.v
@@ -28,7 +28,7 @@ Require Import CoRN.tactics.CornTac.
 
 Opaque CR.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 (**
 ** Example of a real number structure: $\langle$#&lang;#[CR]$\rangle$#&rang;#

--- a/model/rings/CRring.v
+++ b/model/rings/CRring.v
@@ -30,7 +30,7 @@ Require Import CoRN.tactics.CornTac.
 ** Example of a ring: $\langle$#&lang;#[CR],[+],[*]$\rangle$#&rang;#
 *)
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Lemma CRmult_strext : bin_op_strext CRasCSetoid CRmult.
 Proof.

--- a/model/rings/Qring.v
+++ b/model/rings/Qring.v
@@ -38,7 +38,7 @@ Require Export CoRN.model.abgroups.Qabgroup.
 Require Import CoRN.algebra.CRings.
 Require Import CoRN.model.rings.Zring.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (**
 ** Example of a ring: $\langle$#&lang;#[Q],[[+]],[[*]]$\rangle$#&rang;#

--- a/model/semigroups/CRsemigroup.v
+++ b/model/semigroups/CRsemigroup.v
@@ -30,7 +30,7 @@ Require Import CoRN.tactics.CornTac.
 *** $\langle$#&lang;#[CR],[+]$\rangle$#&rang;#
 *)
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Lemma CRplus_strext : bin_op_strext CRasCSetoid (ucFun2 CRplus_uc).
 Proof.

--- a/model/structures/NNUpperR.v
+++ b/model/structures/NNUpperR.v
@@ -8,7 +8,7 @@ Import QnonNeg.notations.
 
 Local Hint Resolve Qle_refl.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (* Some generic utilities: *)
 

--- a/model/structures/OpenUnit.v
+++ b/model/structures/OpenUnit.v
@@ -26,7 +26,7 @@ Require Import CoRN.tactics.CornTac.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (**
 * [OpenUnit]

--- a/model/structures/QposInf.v
+++ b/model/structures/QposInf.v
@@ -28,8 +28,8 @@ Require Import CoRN.model.totalorder.QposMinMax.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
-Open Local Scope Qpos_scope.
+Local Open Scope Q_scope.
+Local Open Scope Qpos_scope.
 
 (**
 * [Qpos]

--- a/model/structures/Qpossec.v
+++ b/model/structures/Qpossec.v
@@ -46,7 +46,7 @@ Require Import Coq.QArith.Qround.
 Require Import Coq.QArith.Qabs.
 Require Import CoRN.stdlib_omissions.Q.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (**
 * [Qpos]

--- a/model/structures/Qsec.v
+++ b/model/structures/Qsec.v
@@ -48,7 +48,7 @@ Require Export Coq.QArith.QArith.
 Require Import CoRN.stdlib_omissions.Q.
 
 Close Scope Q_scope.
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (**
 * [Q]

--- a/model/structures/StepQsec.v
+++ b/model/structures/StepQsec.v
@@ -9,8 +9,8 @@ Require Import CoRN.algebra.RSetoid.
 
 Set Implicit Arguments.
 
-Open Local Scope setoid_scope.
-Open Local Scope sfstscope.
+Local Open Scope setoid_scope.
+Local Open Scope sfstscope.
 
 Section QS.
 
@@ -86,7 +86,7 @@ Instance StepQ_default : @DefaultRelation (StepF QS) (@StepF_eq QS) | 2.
 Delimit Scope StepQ_scope with SQ.
 Bind Scope StepQ_scope with StepF.
 
-Open Local Scope StepQ_scope.
+Local Open Scope StepQ_scope.
 
 Definition StepQplus (s t:StepQ) : StepQ := QplusS ^@> s <@> t.
 Definition StepQopp (s:StepQ) : StepQ := QoppS ^@> s.

--- a/model/totalorder/QposMinMax.v
+++ b/model/totalorder/QposMinMax.v
@@ -186,7 +186,7 @@ Proof.
  apply Qplus_le_compat. assumption. apply Qle_refl.
 Qed.
 
-Open Local Scope Qpos_scope.
+Local Open Scope Qpos_scope.
 
 Definition Qpos_min_plus_distr_r : (forall x y z : Qpos, Qpos_plus x (Qpos_min y z) == Qpos_min (Qpos_plus x y) (Qpos_plus x z))  :=
  fun a => @monotone_meet_distr Qto _ (Qplus_monotone_r a).

--- a/model/totalorder/ZMinMax.v
+++ b/model/totalorder/ZMinMax.v
@@ -30,7 +30,7 @@ Opaque Z_lt_le_dec.
 *)
 Section ZTotalOrder.
 
-Open Local Scope Z_scope.
+Local Open Scope Z_scope.
 
 Definition Zle_total x y : {x <= y} + {y <= x} :=
 match Z_lt_le_dec x y with

--- a/order/Lattice.v
+++ b/order/Lattice.v
@@ -22,7 +22,7 @@ CONNECTION WITH THE PROOF OR THE USE OR OTHER DEALINGS IN THE PROOF.
 Require Import Coq.Setoids.Setoid.
 Require Export CoRN.order.SemiLattice.
 
-Open Local Scope po_scope.
+Local Open Scope po_scope.
 
 (**
 * Lattice

--- a/order/PartialOrder.v
+++ b/order/PartialOrder.v
@@ -55,7 +55,7 @@ Record PartialOrder : Type :=
 Notation "x == y" := (st_eq x y) (at level 70, no associativity) : po_scope.
 Notation "x <= y" := (le _ x y) : po_scope.
 
-Open Local Scope po_scope.
+Local Open Scope po_scope.
 
 Lemma po_st : forall X eq le mnt ant, @is_PartialOrder X eq le mnt ant -> Setoid_Theory X eq.
 Proof with trivial.

--- a/order/SemiLattice.v
+++ b/order/SemiLattice.v
@@ -22,7 +22,7 @@ Set Firstorder Depth 5.
 
 Require Export CoRN.order.PartialOrder.
 
-Open Local Scope po_scope.
+Local Open Scope po_scope.
 
 (**
 * SemiLattice

--- a/order/TotalOrder.v
+++ b/order/TotalOrder.v
@@ -23,7 +23,7 @@ Set Firstorder Depth 5.
 Require Import Coq.Setoids.Setoid.
 Require Export CoRN.order.Lattice.
 
-Open Local Scope po_scope.
+Local Open Scope po_scope.
 (**
 * Total Order
 A total order is a lattice were x <= y or y <= x.

--- a/reals/Q_in_CReals.v
+++ b/reals/Q_in_CReals.v
@@ -92,7 +92,7 @@ Proof.
 Qed.
 (*--------------------------------------*)
 
-Coercion Local nat_of_P : positive >-> nat.
+Local Coercion nat_of_P : positive >-> nat.
 (* end hide *)
 
 (**

--- a/reals/fast/CRAlternatingSum.v
+++ b/reals/fast/CRAlternatingSum.v
@@ -48,7 +48,7 @@ a bound on the error of the partial sum.
 
 Section InfiniteAlternatingSum.
 (* begin hide *)
-Coercion Local Is_true : bool >-> Sortclass.
+Local Coercion Is_true : bool >-> Sortclass.
 (* end hide *)
 (** Given a stream, we can compute its alternating partial sum up to
 an point satifying a predicate, so long as that predicate eventually
@@ -258,7 +258,7 @@ Proof.
   now rewrite (InfiniteAlternatingSum_raw_wd s1 s2).
 Qed.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Lemma InfiniteAlternatingSum_step (seq : Stream Q) {dnn:DecreasingNonNegative seq} {zl:Limit seq 0} : 
  (InfiniteAlternatingSum seq == '(hd seq) - InfiniteAlternatingSum (tl seq))%CR.

--- a/reals/fast/CRArith.v
+++ b/reals/fast/CRArith.v
@@ -37,7 +37,7 @@ Require Import CoRN.util.Qdlog.
 Require Import MathClasses.interfaces.abstract_algebra.
 Require Import MathClasses.interfaces.orders.
 
-Open Local Scope CR_scope.
+Local Open Scope CR_scope.
 
 (** Operations on rational numbers over CR are the same as the operations
 on rational numbers. *)

--- a/reals/fast/CRFieldOps.v
+++ b/reals/fast/CRFieldOps.v
@@ -31,8 +31,8 @@ Require Import MathClasses.interfaces.canonical_names.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 Opaque CR Qmin Qmax Qred.
 
 (**

--- a/reals/fast/CRGeometricSum.v
+++ b/reals/fast/CRGeometricSum.v
@@ -38,7 +38,7 @@ Set Implicit Arguments.
 
 Opaque CR Qabs.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (**
 ** Geometric Series
@@ -67,7 +67,7 @@ match ((err_bound s) ?= err) with
 end.
 
 (* begin hide *)
-Coercion Local Is_true : bool >-> Sortclass.
+Local Coercion Is_true : bool >-> Sortclass.
 (* end hide *)
 
 Lemma err_prop_prop : forall e s, err_prop e s <-> err_bound s <= e.

--- a/reals/fast/CRGroupOps.v
+++ b/reals/fast/CRGroupOps.v
@@ -34,8 +34,8 @@ Set Automatic Introduction.
 
 Opaque CR Qmin Qmax.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 
 Instance CR0: Zero CR := cast Q CR 0.
 Notation "0" := (inject_Q_CR 0) : CR_scope.

--- a/reals/fast/CRabs.v
+++ b/reals/fast/CRabs.v
@@ -29,7 +29,7 @@ Require Import CoRN.reals.fast.CRIR.
 Require Import CoRN.tactics.CornTac.
 Require Import CoRN.logic.Stability.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 (**
 ** Absolute Value
 *)
@@ -52,7 +52,7 @@ Proof.
  apply Qabs_triangle_reverse.
 Qed.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Definition Qabs_uc : Q_as_MetricSpace --> Q_as_MetricSpace :=
 Build_UniformlyContinuousFunction Qabs_uc_prf.
@@ -128,7 +128,7 @@ Proof.
  apply AbsSmall_imp_AbsIR.
 Qed.
 
-Open Local Scope CR_scope.
+Local Open Scope CR_scope.
 
 Lemma CRabs_pos : forall x:CR, 0 <= x -> CRabs x == x.
 Proof.

--- a/reals/fast/CRarctan.v
+++ b/reals/fast/CRarctan.v
@@ -34,8 +34,8 @@ Require Import MathClasses.interfaces.abstract_algebra.
 Require Import Coq.micromega.Psatz.
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 
 Opaque inj_Q CR.
 (**

--- a/reals/fast/CRarctan_small.v
+++ b/reals/fast/CRarctan_small.v
@@ -35,8 +35,8 @@ Require Import CoRN.stdlib_omissions.Q.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 
 Opaque inj_Q CR.
 

--- a/reals/fast/CRartanh_slow.v
+++ b/reals/fast/CRartanh_slow.v
@@ -36,8 +36,8 @@ Require Import CoRN.tactics.CornTac.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 
 Opaque inj_Q CR.
 

--- a/reals/fast/CRcorrect.v
+++ b/reals/fast/CRcorrect.v
@@ -285,7 +285,7 @@ Proof.
  apply Cauchy_IR_eq_as_CR_eq.
 Qed.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 (**
 *** Functions preserved by isomorphism.
 *)

--- a/reals/fast/CRcos.v
+++ b/reals/fast/CRcos.v
@@ -37,8 +37,8 @@ Require Import MathClasses.interfaces.abstract_algebra.
 
 Opaque inj_Q CR Qmin Qmax.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 
 (**
 ** Cosine

--- a/reals/fast/CRexp.v
+++ b/reals/fast/CRexp.v
@@ -48,8 +48,8 @@ Set Implicit Arguments.
 Opaque CR.
 Opaque Exp.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 
 (**
 ** Exponential

--- a/reals/fast/CRln.v
+++ b/reals/fast/CRln.v
@@ -34,8 +34,8 @@ Require Import CoRN.tactics.CornTac.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 
 Opaque inj_Q CR Logarithm.
 

--- a/reals/fast/CRpi_fast.v
+++ b/reals/fast/CRpi_fast.v
@@ -31,8 +31,8 @@ Require Import CoRN.stdlib_omissions.Q.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 
 Opaque inj_Q CR.
 (**

--- a/reals/fast/CRpi_slow.v
+++ b/reals/fast/CRpi_slow.v
@@ -30,8 +30,8 @@ Require Import CoRN.stdlib_omissions.Q.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 
 Opaque inj_Q CR.
 

--- a/reals/fast/CRpower.v
+++ b/reals/fast/CRpower.v
@@ -30,8 +30,8 @@ Require Import MathClasses.interfaces.additional_operations.
 
 Opaque CR inj_Q.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 
 (**
 ** Natural Integer Powers

--- a/reals/fast/CRroot.v
+++ b/reals/fast/CRroot.v
@@ -38,7 +38,7 @@ Require Import CoRN.tactics.Qauto.
 Require Import CoRN.tactics.CornTac.
 Require Import MathClasses.interfaces.abstract_algebra.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Opaque CR.
 Opaque Qmin Qmax.
@@ -925,7 +925,7 @@ Proof.
  apply sqrt_nonneg.
 Qed.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Definition sqrt_uc : Q_as_MetricSpace --> CR :=
 Build_UniformlyContinuousFunction sqrt_uc_prf.

--- a/reals/fast/CRseries.v
+++ b/reals/fast/CRseries.v
@@ -33,7 +33,7 @@ Require Import Coq.setoid_ring.Ring MathClasses.interfaces.abstract_algebra Math
 Require Export MathClasses.theory.series.
 
 Opaque Qabs.
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (**
 ** Specific results for series on [Q]

--- a/reals/fast/CRsin.v
+++ b/reals/fast/CRsin.v
@@ -42,8 +42,8 @@ Require Import MathClasses.interfaces.abstract_algebra.
 
 Set Implicit Arguments.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 
 Opaque inj_Q CR Qmin Qmax.
 

--- a/reals/fast/CRsum.v
+++ b/reals/fast/CRsum.v
@@ -25,7 +25,7 @@ Require Import CoRN.model.rings.Qring.
 Require Import CoRN.tactics.Qauto.
 Require Import CoRN.tactics.CornTac.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Definition CRsum_list_raw (l:list CR) (e:QposInf) : Q :=
 fold_left Qplus

--- a/reals/fast/Compress.v
+++ b/reals/fast/Compress.v
@@ -27,8 +27,8 @@ Require Import CoRN.tactics.CornTac.
 
 Opaque CR.
 
-Open Local Scope Q_scope.
-Open Local Scope uc_scope.
+Local Open Scope Q_scope.
+Local Open Scope uc_scope.
 
 (**
 ** Compression

--- a/reals/fast/ContinuousCorrect.v
+++ b/reals/fast/ContinuousCorrect.v
@@ -29,7 +29,7 @@ Opaque CR inj_Q.
 
 Set Implicit Arguments.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 (**
 ** Correctness of continuous functions.
 We show that if two functions, one on IR and one on CR, agree on the

--- a/reals/fast/Integration.v
+++ b/reals/fast/Integration.v
@@ -47,7 +47,7 @@ Set Implicit Arguments.
 
 Opaque Qmax Qabs inj_Q.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (**
 * Effective Integration
@@ -78,9 +78,9 @@ Proof.
  auto with *.
 Qed.
 
-Open Local Scope setoid_scope.
-Open Local Scope sfstscope.
-Open Local Scope StepQ_scope.
+Local Open Scope setoid_scope.
+Local Open Scope sfstscope.
+Local Open Scope StepQ_scope.
 
 Definition stepSample : positive -> StepQ := positive_rect2
  (fun _ => StepQ)
@@ -531,7 +531,7 @@ Qed.
 Definition distribComplete (x:StepF CR) : BoundedFunction :=
 Build_RegularFunction (distribComplete_prf x).
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 (** Given a uniformly continuous function f, and a step function g,
 the composition f o g is a bounded function.  The map from g to f o g

--- a/reals/fast/Interval.v
+++ b/reals/fast/Interval.v
@@ -30,7 +30,7 @@ Require Import CoRN.model.totalorder.QMinMax.
 Require Import CoRN.logic.Classic.
 Require Import CoRN.tactics.CornTac.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Opaque Qabs.
 
@@ -330,7 +330,7 @@ Qed.
 Definition CompactIntervalQ : Compact stableQ :=
 Build_RegularFunction CompactIntervalQ_prf.
 
-Open Local Scope CR_scope.
+Local Open Scope CR_scope.
 
 Opaque max.
 

--- a/reals/fast/MultivariatePolynomials.v
+++ b/reals/fast/MultivariatePolynomials.v
@@ -189,7 +189,7 @@ match n return MultivariatePolynomial Q_as_CRing n -> Q with
                          (fun c _ _ rec => Qmin (MVP_lowerBound n' c) rec) m b
 end.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (** Definition of the unit hyperinterval of n dimensions *)
 Fixpoint UnitHyperInterval (n:nat) (v:Vector.t Q n) : Prop :=
@@ -481,7 +481,7 @@ Proof.
  reflexivity.
 Qed.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (** Use the upper and lower bounds of the derivative of a polynomial to
 define its modulus of continuity. *)
@@ -566,7 +566,7 @@ Proof.
  reflexivity.
 Qed.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 (** Clamp a value to the unit interval *)
 Definition Qclamp01 := QboundBelow_uc (0) ∘ QboundAbove_uc 1.

--- a/reals/fast/Plot.v
+++ b/reals/fast/Plot.v
@@ -42,7 +42,7 @@ Hypothesis Hlr : l < r.
 Variable (b t:Q).
 Hypothesis Hbt : b < t.
 
-Open Local Scope uc_scope.
+Local Open Scope uc_scope.
 
 Let clip := uc_compose (boundBelow b) (boundAbove t).
 
@@ -97,7 +97,7 @@ Let err := Qpos_max ((1 # 4 * P_of_succ_nat (pred n)) * w)
 (** [PlotQ] is the function that does all the work. *)
 Definition PlotQ := RasterizeQ2 (approximate (graphQ (uc_compose clip f)) err) n m t l b r.
 
-Open Local Scope raster.
+Local Open Scope raster.
 
 (** The resulting plot is close to the graph of [f] *)
 Theorem Plot_correct :

--- a/reals/fast/PowerBound.v
+++ b/reals/fast/PowerBound.v
@@ -27,7 +27,7 @@ Require Import CoRN.algebra.COrdFields2.
 Require Import Coq.QArith.Qpower.
 Require Import CoRN.tactics.CornTac.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 (** These functions effiecently find bounds on rational numbers of the
 form 3^z or 4^z. *)

--- a/reals/fast/RasterQ.v
+++ b/reals/fast/RasterQ.v
@@ -78,8 +78,8 @@ Notation "a ⇱ b ⇲ c" := (InterpRaster b a c) (at level 1,
  format "a ⇱ '[v' '/' b ']' '[v' '/' ⇲ c ']'") : raster.
 
 (*
-Open Local Scope raster.
-Open Local Scope raster_parsing.
+Local Open Scope raster.
+Local Open Scope raster_parsing.
 
 Example ex5 :=
 (0, 1)⇱

--- a/reals/fast/RasterizeQ.v
+++ b/reals/fast/RasterizeQ.v
@@ -27,7 +27,7 @@ Require Import CoRN.tactics.Qauto.
 Require Import Coq.QArith.Qround.
 Require Import CoRN.tactics.CornTac.
 
-Open Local Scope Q_scope.
+Local Open Scope Q_scope.
 
 Set Implicit Arguments.
 

--- a/reals/faster/AQmetric.v
+++ b/reals/faster/AQmetric.v
@@ -9,7 +9,7 @@ Context `{AppRationals AQ}.
 
 Add Ring AQ : (rings.stdlib_ring_theory AQ).
 
-Open Local Scope uc_scope. 
+Local Open Scope uc_scope. 
 
 Definition AQ_as_MetricSpace := Emetric (cast AQ Q_as_MetricSpace).
 Definition AQPrelengthSpace := EPrelengthSpace QPrelengthSpace (cast AQ Q_as_MetricSpace).

--- a/reals/faster/ARArith.v
+++ b/reals/faster/ARArith.v
@@ -15,7 +15,7 @@ Context `{AppRationals AQ}.
 Add Ring AQ : (rings.stdlib_ring_theory AQ).
 Add Ring Z : (rings.stdlib_ring_theory Z).
 
-Open Local Scope uc_scope. 
+Local Open Scope uc_scope. 
 Local Opaque regFunEq.
 
 Hint Rewrite (rings.preserves_0 (f:=cast AQ Q)) : aq_preservation.


### PR DESCRIPTION
It was emitting a deprecation warning and will soon be removed from Coq.

@spitters There are many other deprecation warnings emitted when compiling Corn. Is there any plan to fix those?