### PR TITLE
Change Implicit Arguments to Arguments

### DIFF
--- a/algebra/Bernstein.v
+++ b/algebra/Bernstein.v
@@ -270,8 +270,8 @@ Qed.
 Opaque Bernstein.
 
 (** Given a vector of coefficents for a polynomial in the Bernstein basis, return the polynomial *)
-Implicit Arguments Vector.nil [A].
-Implicit Arguments Vector.cons [A].
+Arguments Vector.nil [A].
+Arguments Vector.cons [A].
 
 Fixpoint evalBernsteinBasisH (n i:nat) (v:Vector.t R i) : i <= n -> cpoly_cring R :=
 match v in Vector.t _ i return i <= n -> cpoly_cring R with

--- a/algebra/CAbGroups.v
+++ b/algebra/CAbGroups.v
@@ -520,5 +520,5 @@ Hint Resolve nmult_wd nmult_one nmult_Zero nmult_plus nmult_inv nmult_mult
   nmult_plus' zmult_wd zmult_one zmult_min_one zmult_zero zmult_Zero
   zmult_plus zmult_mult zmult_plus': algebra.
 
-Implicit Arguments nmult [G].
-Implicit Arguments zmult [G].
+Arguments nmult [G].
+Arguments zmult [G].

--- a/algebra/CFields.v
+++ b/algebra/CFields.v
@@ -96,7 +96,7 @@ Defined.
 
 Definition f_rcpcl F x x_ := f_rcpcl' F x x_.
 
-Implicit Arguments f_rcpcl [F].
+Arguments f_rcpcl [F].
 
 (**
 [cf_div] is the division in a field. It is defined in terms of
@@ -106,7 +106,7 @@ we have a proof of [y [#] [0]].
 
 Definition cf_div (F : CField) (x y : F) y_ : F := x[*]f_rcpcl y y_.
 
-Implicit Arguments cf_div [F].
+Arguments cf_div [F].
 Notation "x [/] y [//] Hy" := (cf_div x y Hy) (at level 80).
 
 (**
@@ -905,10 +905,10 @@ Qed.
 
 End CField_Ops.
 
-Implicit Arguments Frecip [X].
+Arguments Frecip [X].
 Notation "{1/} x" := (Frecip x) (at level 4, right associativity).
 
-Implicit Arguments Fdiv [X].
+Arguments Fdiv [X].
 Infix "{/}" := Fdiv (at level 41, no associativity).
 
 Hint Resolve included_FRecip included_FDiv : included.

--- a/algebra/CGroups.v
+++ b/algebra/CGroups.v
@@ -64,7 +64,7 @@ Record CGroup : Type :=
 (* Begin_SpecReals *)
 
 
-Implicit Arguments cg_inv [c].
+Arguments cg_inv [c].
 Notation "[--] x" := (cg_inv x) (at level 4, right associativity).
 
 Definition cg_minus (G : CGroup) (x y : G) := x[+] [--]y.
@@ -76,7 +76,7 @@ and [ [-] ] with [minus].
 %\end{nameconvention}%
 *)
 
-Implicit Arguments cg_minus [G].
+Arguments cg_minus [G].
 Infix "[-]" := cg_minus (at level 50, left associativity).
 
 (* End_SpecReals *)
@@ -607,10 +607,10 @@ Qed.
 
 End CGroup_Ops.
 
-Implicit Arguments Finv [G].
+Arguments Finv [G].
 Notation "{--} x" := (Finv x) (at level 4, right associativity).
 
-Implicit Arguments Fminus [G].
+Arguments Fminus [G].
 Infix "{-}" := Fminus (at level 50, left associativity).
 
 Hint Resolve included_FInv included_FMinus : included.

--- a/algebra/CMonoids.v
+++ b/algebra/CMonoids.v
@@ -82,7 +82,7 @@ Definition nonZeroP (M : CMonoid) (x : M) : CProp := x [#] [0].
 
 (* End_SpecReals *)
 
-Implicit Arguments nonZeroP [M].
+Arguments nonZeroP [M].
 
 (**
 ** Monoid axioms
@@ -291,7 +291,7 @@ end.
 
 End p71E1.
 
-Implicit Arguments power_CMonoid [M].
+Arguments power_CMonoid [M].
 
 Lemma power_plus:forall (M:CMonoid)(a:M)(m n:nat),
   (power_CMonoid a (m+n))[=]
@@ -626,7 +626,7 @@ End gen_cyc.
 Definition is_inverse S (op : CSetoid_bin_op S) Zero x x_inv : Prop :=
  op x x_inv [=] Zero /\ op x_inv x [=] Zero.
 
-Implicit Arguments is_inverse [S].
+Arguments is_inverse [S].
 
 Definition invertible (M:CMonoid): M -> CProp :=
 fun m =>{inv: (CSetoid_un_op M) | (is_inverse csg_op (@cm_unit M) m (inv m))}.

--- a/algebra/COrdAbs.v
+++ b/algebra/COrdAbs.v
@@ -44,7 +44,7 @@ Require Export CoRN.algebra.COrdFields2.
 
 Definition AbsSmall (R : COrdField) (e x : R) : Prop := [--]e [<=] x /\ x [<=] e.
 
-Implicit Arguments AbsSmall [R].
+Arguments AbsSmall [R].
 
 (* End_SpecReals *)
 

--- a/algebra/COrdCauchy.v
+++ b/algebra/COrdCauchy.v
@@ -287,7 +287,7 @@ Qed.
 
 End OrdField_Cauchy.
 
-Implicit Arguments SeqLimit [R].
+Arguments SeqLimit [R].
 
 (**
 The following lemma does not require the sequence to be Cauchy, but it fits

--- a/algebra/COrdFields.v
+++ b/algebra/COrdFields.v
@@ -68,10 +68,10 @@ Record strictorder (A : Type)(R : A -> A -> CProp) : CProp :=
  {so_trans : Ctransitive R;
   so_asym  : antisymmetric R}.
 
-Implicit Arguments strictorder [A].
-Implicit Arguments Build_strictorder [A R].
-Implicit Arguments so_trans [A R].
-Implicit Arguments so_asym [A R].
+Arguments strictorder [A].
+Arguments Build_strictorder [A R].
+Arguments so_trans [A R].
+Arguments so_asym [A R].
 
 Record is_COrdField (F : CField)
   (less : CCSetoid_relation F) (leEq : Relation F)
@@ -99,16 +99,16 @@ is written as [pos].
 %\end{nameconvention}%
 *)
 
-Implicit Arguments cof_less [c].
+Arguments cof_less [c].
 Infix "[<]" := cof_less (at level 70, no associativity).
 
-Implicit Arguments cof_greater [c].
+Arguments cof_greater [c].
 Infix "[>]" := cof_greater (at level 70, no associativity).
 
-Implicit Arguments cof_leEq [c].
+Arguments cof_leEq [c].
 Infix "[<=]" := cof_leEq (at level 70, no associativity).
 
-Implicit Arguments cof_grEq [c].
+Arguments cof_grEq [c].
 Infix "[>=]" := cof_grEq (at level 70, no associativity).
 
 Definition default_greater (X:CField) (lt:CCSetoid_relation X) : CCSetoid_relation X.

--- a/algebra/COrdFields2.v
+++ b/algebra/COrdFields2.v
@@ -1093,7 +1093,7 @@ Hint Resolve mult_resp_nonneg.
 
 Definition one_div_succ (R : COrdField) i : R := [1][/] Snring R i[//]nringS_ap_zero _ i.
 
-Implicit Arguments one_div_succ [R].
+Arguments one_div_succ [R].
 
 Section One_div_succ_properties.
 
@@ -1136,7 +1136,7 @@ End One_div_succ_properties.
 
 Definition Half (R : COrdField) := ([1]:R) [/]TwoNZ.
 
-Implicit Arguments Half [R].
+Arguments Half [R].
 
 Section Half_properties.
 

--- a/algebra/CPoly_ApZero.v
+++ b/algebra/CPoly_ApZero.v
@@ -47,7 +47,7 @@ Set Automatic Introduction.
 
 Definition distinct1 (A : CSetoid) (f : nat -> A) := forall i j, i <> j -> f i [#] f j.
 
-Implicit Arguments distinct1 [A].
+Arguments distinct1 [A].
 
 Section Poly_Representation.
 (**

--- a/algebra/CPoly_Degree.v
+++ b/algebra/CPoly_Degree.v
@@ -64,8 +64,8 @@ is always [1] higher than the `degree' (assuming that the highest
 coefficient is [[#][0]])!
 *)
 
-Implicit Arguments cpoly_zero [CR].
-Implicit Arguments cpoly_linear [CR].
+Arguments cpoly_zero [CR].
+Arguments cpoly_linear [CR].
 
 Fixpoint lth_of_poly (p : RX) : nat :=
   match p with
@@ -102,10 +102,10 @@ Definition regular (p : RX) : CProp := {n : nat | degree n p}.
 
 End Degree_def.
 
-Implicit Arguments degree_le [R].
-Implicit Arguments degree [R].
-Implicit Arguments monic [R].
-Implicit Arguments lth_of_poly [R].
+Arguments degree_le [R].
+Arguments degree [R].
+Arguments monic [R].
+Arguments lth_of_poly [R].
 
 Section Degree_props.
 

--- a/algebra/CPoly_Newton.v
+++ b/algebra/CPoly_Newton.v
@@ -552,7 +552,7 @@ Notation "x ∈ y" := (In y x) (at level 40).
 Notation "(∈ y )" := (In y) (at level 40).
 Notation "x ∉ y" := (In y x → False) (at level 40).
 Instance in_QRange: Container Q (Range Q) := λ r x, fst r <= x <= snd r. 
-Implicit Arguments proj1_sig [[A] [P]].
+Arguments proj1_sig {A P}.
 Program Instance in_sig_QRange (P: Q → Prop): Container (sig P) (Range (sig P)) := λ r x, fst r <= x <= snd r. 
 Definition B01: Ball Q Qpos := (1#2, (1#2)%Qpos).
 (*Definition D01 := sig (contains B01).

--- a/algebra/CPoly_NthCoeff.v
+++ b/algebra/CPoly_NthCoeff.v
@@ -61,8 +61,8 @@ The [n]-th coefficient of a polynomial. The default value is
 polynomial $a_0 +a_1 X +a_2 X^2 + \cdots + a_n X^n$ #a0 +a1 X +a2 X^2
 + ... + an X^n#, the [Zero]-th coefficient is $a_0$#a0#, the first
 is $a_1$#a1# etcetera.  *)
-Implicit Arguments cpoly_zero [CR].
-Implicit Arguments cpoly_linear [CR].
+Arguments cpoly_zero [CR].
+Arguments cpoly_linear [CR].
 
 Fixpoint nth_coeff (n : nat) (p : RX) {struct p} : R :=
   match p with
@@ -183,8 +183,8 @@ Qed.
 
 End NthCoeff_def.
 
-Implicit Arguments nth_coeff [R].
-Implicit Arguments nth_coeff_fun [R].
+Arguments nth_coeff [R].
+Arguments nth_coeff_fun [R].
 
 Hint Resolve nth_coeff_wd: algebra_c.
 

--- a/algebra/CPolynomials.v
+++ b/algebra/CPolynomials.v
@@ -1800,7 +1800,7 @@ Notation "'_X_'" := (@cpoly_var _).
 Definition cpoly_linear_fun' (CR : CRing) :
  CSetoid_bin_fun CR (cpoly_cring CR) (cpoly_cring CR) := cpoly_linear_fun CR.
 
-Implicit Arguments cpoly_linear_fun' [CR].
+Arguments cpoly_linear_fun' [CR].
 Infix "[+X*]" := cpoly_linear_fun' (at level 50, left associativity).
 
 
@@ -2001,7 +2001,7 @@ In the names of lemmas, we write [apply].
 %\end{convention}%
 *)
 
-Implicit Arguments cpoly_apply_fun [CR].
+Arguments cpoly_apply_fun [CR].
 Infix "!" := cpoly_apply_fun (at level 1, no associativity).
 
 (**
@@ -2759,7 +2759,7 @@ Proof.
 Qed.
 
 End Map.
-Implicit Arguments cpoly_map [R S].
+Arguments cpoly_map [R S].
 
 Lemma cpoly_map_compose : forall R S T (g:RingHom S T) (f:RingHom R S) p,
  (cpoly_map (RHcompose _ _ _ g f) p)[=]cpoly_map g (cpoly_map f p).

--- a/algebra/CRings.v
+++ b/algebra/CRings.v
@@ -72,7 +72,7 @@ We actually define commutative rings with identity.
 Definition distributive S (mult plus : CSetoid_bin_op S) :=
   forall x y z, mult x (plus y z) [=] plus (mult x y) (mult x z).
 
-Implicit Arguments distributive [S].
+Arguments distributive [S].
 
 Record is_CRing (G : CAbGroup) (One : G) (mult : CSetoid_bin_op G) : CProp :=
   {ax_mult_assoc : associative mult;
@@ -104,7 +104,7 @@ and [[*]] with [mult].
 %\end{nameconvention}%
 *)
 
-Implicit Arguments cr_mult [c].
+Arguments cr_mult [c].
 Infix "[*]" := cr_mult (at level 40, left associativity).
 
 Section CRing_axioms.
@@ -249,8 +249,8 @@ Definition is_zero_rht S (op : CSetoid_bin_op S) Zero : Prop := forall x, op x Z
 
 Definition is_zero_lft S (op : CSetoid_bin_op S) Zero : Prop := forall x, op Zero x [=] Zero.
 
-Implicit Arguments is_zero_rht [S].
-Implicit Arguments is_zero_lft [S].
+Arguments is_zero_rht [S].
+Arguments is_zero_lft [S].
 
 Lemma cring_mult_zero : forall x : R, x[*][0] [=] [0].
 Proof.
@@ -412,7 +412,7 @@ End exponentiation.
 (* End_SpecReals *)
 
 Notation "x [^] n" := (nexp_op _ n x) (at level 20).
-Implicit Arguments nexp_op [R].
+Arguments nexp_op [R].
 
 (* Begin_SpecReals *)
 
@@ -462,7 +462,7 @@ End nat_injection.
 
 Hint Resolve nring_comm_plus nring_comm_mult: algebra.
 
-Implicit Arguments nring [R].
+Arguments nring [R].
 
 Notation Two := (nring 2).
 Notation Three := (nring 3).
@@ -837,7 +837,7 @@ Qed.
 
 End int_injection.
 
-Implicit Arguments zring [R].
+Arguments zring [R].
 
 Hint Resolve pring_convert zring_zero zring_diff zring_plus_nat zring_inv_nat
   zring_plus zring_inv zring_minus zring_mult zring_one zring_inv_one:
@@ -1287,13 +1287,13 @@ End CRing_Ops.
 
 Definition Fscalmult (R:CRing) alpha F := Fmult R [-C-]alpha F.
 
-Implicit Arguments Fmult [R].
+Arguments Fmult [R].
 Infix "{*}" := Fmult (at level 40, left associativity).
 
-Implicit Arguments Fscalmult [R].
+Arguments Fscalmult [R].
 Infix "{**}" := Fscalmult (at level 40, left associativity).
 
-Implicit Arguments Fnth [R].
+Arguments Fnth [R].
 Infix "{^}" := Fnth (at level 30, right associativity).
 
 Section ScalarMultiplication.

--- a/algebra/CSemiGroups.v
+++ b/algebra/CSemiGroups.v
@@ -59,7 +59,7 @@ In the %{\em %names%}% of lemmas, we will denote [[+]] with [plus].
 %\end{nameconvention}%
 *)
 
-Implicit Arguments csg_op [c].
+Arguments csg_op [c].
 Infix "[+]" := csg_op (at level 50, left associativity).
 (* End_SpecReals *)
 
@@ -133,11 +133,11 @@ Definition is_rht_unit S (op : CSetoid_bin_op S) Zero : Prop := forall x, op x Z
 
 Definition is_lft_unit S (op : CSetoid_bin_op S) Zero : Prop := forall x, op Zero x [=] x.
 
-Implicit Arguments is_lft_unit [S].
+Arguments is_lft_unit [S].
 
 (* Begin_SpecReals *)
 
-Implicit Arguments is_rht_unit [S].
+Arguments is_rht_unit [S].
 
 (** An alternative definition:
 *)
@@ -227,7 +227,7 @@ Qed.
 
 End Part_Function_Plus.
 
-Implicit Arguments Fplus [G].
+Arguments Fplus [G].
 Infix "{+}" := Fplus (at level 50, left associativity).
 
 Hint Resolve included_FPlus : included.

--- a/algebra/CSetoidFun.v
+++ b/algebra/CSetoidFun.v
@@ -727,11 +727,11 @@ End Extension.
 End SubSets_of_G.
 
 Notation Conj := (conjP _).
-Implicit Arguments disj [S].
+Arguments disj [S].
 
-Implicit Arguments extend [S].
-Implicit Arguments ext1 [S P R x].
-Implicit Arguments ext2 [S P R x].
+Arguments extend [S].
+Arguments ext1 [S P R x].
+Arguments ext2 [S P R x].
 
 (**
 *** Operations
@@ -747,7 +747,7 @@ Record BinPartFunct (S1 S2 : CSetoid) : Type :=
 
 
 Notation BDom := (bpfdom _ _).
-Implicit Arguments bpfpfun [S1 S2].
+Arguments bpfpfun [S1 S2].
 
 (**
 The next lemma states that every partial function is well defined.
@@ -772,7 +772,7 @@ Record PartFunct (S : CSetoid) : Type :=
 
 Notation Dom := (pfdom _).
 Notation Part := (pfpfun _).
-Implicit Arguments pfpfun [S].
+Arguments pfpfun [S].
 
 (**
 The next lemma states that every partial function is well defined.
@@ -957,12 +957,12 @@ End BinPart_Function_Composition.
 
 (* Different tokens for compatibility with coqdoc *)
 
-Implicit Arguments Fconst [S].
+Arguments Fconst [S].
 Notation "[-C-] x" := (Fconst x) (at level 4, right associativity).
 
 Notation FId := (Fid _).
 
-Implicit Arguments Fcomp [S].
+Arguments Fcomp [S].
 Infix "[o]" := Fcomp (at level 65, no associativity).
 
 Hint Resolve pfwdef bpfwdef: algebra.
@@ -979,9 +979,9 @@ Definition injective_weak A B (f : CSetoid_fun A B) := forall a0 a1 : A,
 
 Definition surjective A B (f : CSetoid_fun A B) := (forall b : B, {a : A | f a [=] b}):CProp.
 
-Implicit Arguments injective [A B].
-Implicit Arguments injective_weak [A B].
-Implicit Arguments surjective [A B].
+Arguments injective [A B].
+Arguments injective_weak [A B].
+Arguments surjective [A B].
 
 Lemma injective_imp_injective_weak : forall A B (f : CSetoid_fun A B),
  injective f -> injective_weak f.
@@ -1003,7 +1003,7 @@ Qed.
 
 Definition bijective A B (f:CSetoid_fun A B) := injective f and surjective f.
 
-Implicit Arguments bijective [A B].
+Arguments bijective [A B].
 
 Lemma id_is_bij : forall A, bijective (id_un_op A).
 Proof.
@@ -1038,7 +1038,7 @@ Proof.
  intuition.
 Qed.
 
-Implicit Arguments inv [A B].
+Arguments inv [A B].
 
 Definition invfun A B (f : CSetoid_fun A B) (H : bijective f) : B -> A.
 Proof.
@@ -1047,7 +1047,7 @@ Proof.
  apply a.
 Defined.
 
-Implicit Arguments invfun [A B].
+Arguments invfun [A B].
 
 Lemma inv1 : forall A B (f : CSetoid_fun A B) (H : bijective f) (b : B),
  f (invfun f H b) [=] b.
@@ -1091,7 +1091,7 @@ Qed.
 Definition Inv A B f (H : bijective f) :=
   Build_CSetoid_fun B A (invfun f H) (inv_strext A B f H).
 
-Implicit Arguments Inv [A B].
+Arguments Inv [A B].
 
 Definition Inv_bij : forall A B (f : CSetoid_fun A B) (H : bijective f),
   bijective (Inv f H).
@@ -1128,15 +1128,15 @@ Qed.
 
 
 End bijections.
-Implicit Arguments bijective [A B].
-Implicit Arguments injective [A B].
-Implicit Arguments injective_weak [A B].
-Implicit Arguments surjective [A B].
-Implicit Arguments inv [A B].
-Implicit Arguments invfun [A B].
-Implicit Arguments Inv [A B].
+Arguments bijective [A B].
+Arguments injective [A B].
+Arguments injective_weak [A B].
+Arguments surjective [A B].
+Arguments inv [A B].
+Arguments invfun [A B].
+Arguments Inv [A B].
 
-Implicit Arguments conj_wd [S P Q].
+Arguments conj_wd [S P Q].
 
 Notation Prj1 := (prj1 _ _ _ _).
 Notation Prj2 := (prj2 _ _ _ _).

--- a/algebra/CSetoidInc.v
+++ b/algebra/CSetoidInc.v
@@ -146,7 +146,7 @@ Qed.
 
 End inclusion.
 
-Implicit Arguments included [S].
+Arguments included [S].
 
 Hint Resolve included_refl included_FComp : included.
 

--- a/algebra/CSetoids.v
+++ b/algebra/CSetoids.v
@@ -60,13 +60,13 @@ Open Scope corn_scope.
 
 Definition Relation := Trelation.
 
-Implicit Arguments Treflexive [A].
-Implicit Arguments Creflexive [A].
+Arguments Treflexive [A].
+Arguments Creflexive [A].
 
-Implicit Arguments Tsymmetric [A].
-Implicit Arguments Csymmetric [A].
-Implicit Arguments Ttransitive [A].
-Implicit Arguments Ctransitive [A].
+Arguments Tsymmetric [A].
+Arguments Csymmetric [A].
+Arguments Ttransitive [A].
+Arguments Ctransitive [A].
 
 (* begin hide *)
 Set Implicit Arguments.
@@ -119,7 +119,7 @@ Record CSetoid : Type := makeCSetoid
    cs_proof :  is_CSetoid cs_crr (@st_eq cs_crr) cs_ap}.
 
 Notation cs_eq := st_eq (only parsing).
-Implicit Arguments cs_ap [c].
+Arguments cs_ap [c].
 
 Infix "[=]" := cs_eq (at level 70, no associativity).
 Infix "[#]" := cs_ap (at level 70, no associativity).
@@ -128,7 +128,7 @@ Infix "[#]" := cs_ap (at level 70, no associativity).
 
 Definition cs_neq (S : CSetoid) : Relation S := fun x y : S => ~ x [=] y.
 
-Implicit Arguments cs_neq [S].
+Arguments cs_neq [S].
 
 Infix "[~=]" := cs_neq (at level 70, no associativity).
 
@@ -407,7 +407,7 @@ Definition ProdCSetoid (A B : CSetoid) : CSetoid := Build_CSetoid
  (prodT A B) (prod_eq A B) (prod_ap A B) (prodcsetoid_is_CSetoid A B).
 
 End product_csetoid.
-Implicit Arguments ex_unq [S].
+Arguments ex_unq [S].
 
 Hint Resolve eq_reflexive_unfolded ap_irreflexive_unfolded: algebra_r.
 Hint Resolve eq_symmetric_unfolded ap_symmetric_unfolded: algebra_s.
@@ -810,8 +810,8 @@ Definition bin_fun2fun_lft (S1 S2 S3:CSetoid) (f : CSetoid_bin_fun S1 S2 S3) (c 
 
 Hint Resolve csf_wd_unfolded csbf_wd_unfolded csf_strext_unfolded: algebra_c.
 
-Implicit Arguments fun_wd [S1 S2].
-Implicit Arguments fun_strext [S1 S2].
+Arguments fun_wd [S1 S2].
+Arguments fun_strext [S1 S2].
 
 (**
 ** The unary and binary (inner) operations on a csetoid
@@ -920,8 +920,8 @@ Proof cs_bin_op_strext.
 
 End csetoid_inner_ops.
 
-Implicit Arguments commutes [S].
-Implicit Arguments associative [S].
+Arguments commutes [S].
+Arguments associative [S].
 
 (* Needs to be unfolded to be used as a Hint *)
 Hint Resolve ap_wdr_unfolded ap_wdl_unfolded  bin_op_wd_unfolded un_op_wd_unfolded : algebra_c.
@@ -1165,8 +1165,8 @@ Definition nat_less_n_fun (S : CSetoid) (n : nat) (f : forall i : nat, i < n -> 
 Definition nat_less_n_fun' (S : CSetoid) (n : nat) (f : forall i : nat, i <= n -> S) :=
   forall i j : nat, i = j -> forall (H : i <= n) (H' : j <= n), f i H [=] f j H'.
 
-Implicit Arguments nat_less_n_fun [S n].
-Implicit Arguments nat_less_n_fun' [S n].
+Arguments nat_less_n_fun [S n].
+Arguments nat_less_n_fun' [S n].
 
 Add Parametric Relation c : (cs_crr c) (@cs_eq c)
   reflexivity proved by (eq_reflexive c)

--- a/algebra/CSums.v
+++ b/algebra/CSums.v
@@ -631,10 +631,10 @@ Qed.
 
 End Sums.
 
-Implicit Arguments Sum [G].
-Implicit Arguments Sum0 [G].
-Implicit Arguments Sumx [G n].
-Implicit Arguments Sum2 [G m n].
+Arguments Sum [G].
+Arguments Sum0 [G].
+Arguments Sumx [G n].
+Arguments Sum2 [G m n].
 
 (**
 The next results are useful for calculating some special sums,

--- a/algebra/CornScope.v
+++ b/algebra/CornScope.v
@@ -2,14 +2,14 @@ Require Export CoRN.algebra.CSetoids.
 Delimit Scope corn_scope with corn.
 (* Open Scope corn_scope.*)
 
-Arguments Scope cs_ap [ _ corn_scope corn_scope].
-Arguments Scope cs_eq [ _ corn_scope corn_scope].
+Arguments cs_ap _ _%corn_scope _%corn_scope.
+Arguments cs_eq _ _%corn_scope _%corn_scope.
 
 (* Infix "#" := cs_ap (at level 70, no associativity) : corn_scope. *)
 Infix "==" := cs_eq (at level 70, no associativity) : corn_scope.
 
 Require Import CoRN.algebra.CSemiGroups.
-Arguments Scope csg_op [ _ corn_scope corn_scope ].
+Arguments csg_op _ _%corn_scope _%corn_scope : extra scopes.
 Infix "+" := csg_op (at level 50, left associativity) : corn_scope.
 
 
@@ -22,7 +22,7 @@ Notation "- x" := (cg_inv x) (at level 35, right associativity) : corn_scope.
 Infix "-" := cg_minus (at level 50, left associativity) : corn_scope.
 
 Require Import CoRN.algebra.CRings.
-Arguments Scope cr_mult [ _ corn_scope corn_scope ].
+Arguments cr_mult _ _%corn_scope _%corn_scope : extra scopes.
 Infix "*" := cr_mult (at level 40, left associativity) : corn_scope.
 Notation "x ^ n" := (nexp_op _ n x) : corn_scope.
 Notation "1" := [1] : corn_scope.

--- a/algebra/Expon.v
+++ b/algebra/Expon.v
@@ -352,7 +352,7 @@ End More_Nexp.
 
 Hint Resolve nexp_distr_div nexp_distr_recip: algebra.
 
-Implicit Arguments nexp_resp_ap_zero [R x].
+Arguments nexp_resp_ap_zero [R x].
 
 (**
 ** Definition of [zexp]: integer exponentiation
@@ -378,7 +378,7 @@ Definition zexp (x : R) x_ (n : Z) : R :=
 
 End Zexp_def.
 
-Implicit Arguments zexp [R].
+Arguments zexp [R].
 Notation "( x [//] Hx ) [^^] n" := (zexp x Hx n) (at level 0).
 
 (**

--- a/algebra/RSetoid.v
+++ b/algebra/RSetoid.v
@@ -44,10 +44,10 @@ Typeclasses Transparent Equiv.
 Hint Extern 10 (Equiv _) => apply @st_eq : typeclass_instances.
 Hint Extern 10 (Setoid _) => apply @st_isSetoid  : typeclass_instances.
 
-Implicit Arguments st_eq [r].
+Arguments st_eq [r].
 
 Definition mcSetoid_as_RSetoid X {e : Equiv X} {setoid : Setoid X} : RSetoid := Build_RSetoid setoid.
-Implicit Arguments mcSetoid_as_RSetoid [[e] [setoid]].
+Arguments mcSetoid_as_RSetoid X {e setoid}.
 
 (* Canonical Structure mcSetoid_as_RSetoid. *)
 (* If we make this a canonical structure StepQsec will break: investigate *)
@@ -90,7 +90,7 @@ Proof.
  abstract (auto).
 Defined.
 (* begin hide *)
-Implicit Arguments id [X].
+Arguments id [X].
 (* end hide *)
 Definition compose0 X Y Z (x : Y ->Z) (y:X -> Y) z := x (y z).
 
@@ -115,7 +115,7 @@ Proof.
  abstract ( intros x1 x2 H y z; apply: H).
 Defined.
 (* begin hide *)
-Implicit Arguments compose [X Y Z].
+Arguments compose [X Y Z].
 (* end hide *)
 Definition const0 (X Y : RSetoid) : X->Y-->X.
 Proof.
@@ -130,7 +130,7 @@ Proof.
  abstract ( intros x1 x2 Hx y; assumption).
 Defined.
 (* begin hide *)
-Implicit Arguments const [X Y].
+Arguments const [X Y].
 (* end hide *)
 Definition flip0 (X Y Z : RSetoid) : (X-->Y-->Z)->Y->X-->Z.
 Proof.
@@ -152,7 +152,7 @@ Proof.
  abstract ( intros x1 x2 H y z; apply: H).
 Defined.
 (* begin hide *)
-Implicit Arguments flip [X Y Z].
+Arguments flip [X Y Z].
 (* end hide *)
 Definition join0 (X Y : RSetoid) : (X-->X-->Y)->X-->Y.
 Proof.
@@ -168,12 +168,12 @@ Proof.
  abstract ( intros x1 x2 H y; apply: H).
 Defined.
 (* begin hide *)
-Implicit Arguments join [X Y].
+Arguments join [X Y].
 (* end hide *)
 Definition ap (X Y Z : RSetoid) : (X --> Y --> Z) --> (X --> Y) --> (X --> Z)
 := compose (compose (compose (@join _ _)) (@flip _ _ _)) (compose (@compose _ _ _)).
 (* begin hide *)
-Implicit Arguments ap [X Y Z].
+Arguments ap [X Y Z].
 (* end hide *)
 
 Definition bind (X Y Z : RSetoid) : (X--> Y) --> (Y --> X--> Z) --> (X--> Z):=
@@ -183,6 +183,6 @@ Definition bind_compose (X Y Z W : RSetoid) :
  (W--> X--> Y) --> (Y --> X--> Z) --> (W--> X--> Z):=
  (flip (compose (@compose W _ _) ((flip (@bind X Y Z))))).
 (* begin hide *)
-Implicit Arguments bind [X Y Z].
-Implicit Arguments bind_compose [X Y Z W].
+Arguments bind [X Y Z].
+Arguments bind_compose [X Y Z W].
 (* end hide *)

--- a/fta/CPoly_Rev.v
+++ b/fta/CPoly_Rev.v
@@ -160,7 +160,7 @@ End Monomials.
 
 Hint Resolve monom_coeff monom_coeff' monom_mult monom_sum: algebra.
 
-Implicit Arguments monom [R].
+Arguments monom [R].
 
 Section Poly_Reverse.
 
@@ -405,4 +405,4 @@ End Poly_Reverse.
 Hint Resolve Rev_wd: algebra_c.
 Hint Resolve Rev_rev Rev_mult: algebra.
 
-Implicit Arguments Rev [R].
+Arguments Rev [R].

--- a/ftc/Continuity.v
+++ b/ftc/Continuity.v
@@ -360,8 +360,8 @@ Qed.
 
 End Definitions_and_Basic_Results.
 
-Implicit Arguments Continuous_I [a b].
-Implicit Arguments Norm_Funct [a b Hab F].
+Arguments Continuous_I [a b].
+Arguments Norm_Funct [a b Hab F].
 
 Section Local_Results.
 

--- a/ftc/Derivative.v
+++ b/ftc/Derivative.v
@@ -85,7 +85,7 @@ Definition Derivative_I F' (P':=Dom F') := included I (Dom F) and included I (Do
 
 End Definitions.
 
-Implicit Arguments Derivative_I [a b].
+Arguments Derivative_I [a b].
 
 Section Basic_Properties.
 

--- a/ftc/Differentiability.v
+++ b/ftc/Differentiability.v
@@ -76,7 +76,7 @@ Definition Diffble_I (a b : IR) (Hab : a [<] b) (F : PartIR) :=
 
 End Definitions.
 
-Implicit Arguments Diffble_I [a b].
+Arguments Diffble_I [a b].
 
 Section Local_Properties.
 

--- a/ftc/FTC.v
+++ b/ftc/FTC.v
@@ -95,7 +95,7 @@ Defined.
 
 End Indefinite_Integral.
 
-Implicit Arguments Fprim [I F].
+Arguments Fprim [I F].
 
 Notation "[-S-] F" := (Fprim F) (at level 20).
 

--- a/ftc/FunctSeries.v
+++ b/ftc/FunctSeries.v
@@ -141,7 +141,7 @@ Defined.
 
 End Definitions.
 
-Implicit Arguments Fun_Series_Sum [a b Hab f].
+Arguments Fun_Series_Sum [a b Hab f].
 
 Hint Resolve fun_seq_part_sum_cont: continuous.
 

--- a/ftc/FunctSums.v
+++ b/ftc/FunctSums.v
@@ -313,8 +313,8 @@ Definition ext_fun_seq n (f : forall i, i < n -> PartIR) := forall i j, i = j ->
 Definition ext_fun_seq' n (f : forall i, i < n -> PartIR) := forall i j, i = j ->
   forall Hi Hj x y, x [=] y -> Dom (f i Hi) x -> Dom (f j Hj) y.
 
-Implicit Arguments ext_fun_seq [n].
-Implicit Arguments ext_fun_seq' [n].
+Arguments ext_fun_seq [n].
+Arguments ext_fun_seq' [n].
 
 (**
 Under these assumptions, we can characterize the domain and the value of the sum function from the domains and values of the summands:

--- a/ftc/IntervalFunct.v
+++ b/ftc/IntervalFunct.v
@@ -249,14 +249,14 @@ Definition IComp := Build_CSetoid_fun _ _
 
 End Composition.
 
-Implicit Arguments IConst [a b Hab].
-Implicit Arguments IId [a b Hab].
-Implicit Arguments IPlus [a b Hab].
-Implicit Arguments IInv [a b Hab].
-Implicit Arguments IMinus [a b Hab].
-Implicit Arguments IMult [a b Hab].
-Implicit Arguments INth [a b Hab].
-Implicit Arguments IRecip [a b Hab].
-Implicit Arguments IDiv [a b Hab].
-Implicit Arguments IAbs [a b Hab].
-Implicit Arguments IComp [a b Hab a' b' Hab'].
+Arguments IConst [a b Hab].
+Arguments IId [a b Hab].
+Arguments IPlus [a b Hab].
+Arguments IInv [a b Hab].
+Arguments IMinus [a b Hab].
+Arguments IMult [a b Hab].
+Arguments INth [a b Hab].
+Arguments IRecip [a b Hab].
+Arguments IDiv [a b Hab].
+Arguments IAbs [a b Hab].
+Arguments IComp [a b Hab a' b' Hab'].

--- a/ftc/MoreFunSeries.v
+++ b/ftc/MoreFunSeries.v
@@ -679,7 +679,7 @@ Qed.
 
 End Series_Definitions.
 
-Implicit Arguments FSeries_Sum [J f].
+Arguments FSeries_Sum [J f].
 
 Section More_Series_Definitions.
 

--- a/ftc/MoreIntegrals.v
+++ b/ftc/MoreIntegrals.v
@@ -132,7 +132,7 @@ Qed.
 
 End Definitions.
 
-Implicit Arguments Integral [a b Hab F].
+Arguments Integral [a b Hab F].
 
 Section Properties_of_Integral.
 

--- a/ftc/MoreIntervals.v
+++ b/ftc/MoreIntervals.v
@@ -419,8 +419,8 @@ Qed.
 
 End Intervals.
 
-Implicit Arguments Lend [I].
-Implicit Arguments Rend [I].
+Arguments Lend [I].
+Arguments Rend [I].
 
 Section Compact_Constructions.
 

--- a/ftc/NthDerivative.v
+++ b/ftc/NthDerivative.v
@@ -86,8 +86,8 @@ Fixpoint Diffble_I_n (n : nat) (F : PartIR) {struct n} : CProp :=
 
 End Nth_Derivative.
 
-Implicit Arguments Derivative_I_n [a b].
-Implicit Arguments Diffble_I_n [a b].
+Arguments Derivative_I_n [a b].
+Arguments Diffble_I_n [a b].
 
 Section Trivia.
 

--- a/ftc/PartInterval.v
+++ b/ftc/PartInterval.v
@@ -84,7 +84,7 @@ Defined.
 
 End Conversion.
 
-Implicit Arguments IntPartIR [F a b Hab].
+Arguments IntPartIR [F a b Hab].
 
 Section AntiConversion.
 
@@ -117,7 +117,7 @@ Defined.
 
 End AntiConversion.
 
-Implicit Arguments PartInt [a b Hab].
+Arguments PartInt [a b Hab].
 
 Section Inverses.
 

--- a/ftc/Partitions.v
+++ b/ftc/Partitions.v
@@ -287,8 +287,8 @@ Definition Partition_Sum g F (H : Points_in_Partition g) (incF : included (Compa
 
 End Refinements.
 
-Implicit Arguments Points_in_Partition [a b Hab n].
-Implicit Arguments Partition_Sum [a b Hab n P g F].
+Arguments Points_in_Partition [a b Hab n].
+Arguments Partition_Sum [a b Hab n P g F].
 
 (**
 ** Constructions
@@ -360,17 +360,17 @@ Defined.
 
 End Definitions.
 
-Implicit Arguments Partition [a b].
-Implicit Arguments Partition_Dom [a b Hab n].
-Implicit Arguments Mesh [a b Hab n].
-Implicit Arguments AntiMesh [a b Hab n].
-Implicit Arguments Pts [a b Hab lng].
-Implicit Arguments Part_Mesh_List [n a b Hab].
-Implicit Arguments Points_in_Partition [a b Hab n].
-Implicit Arguments Partition_Sum [a b Hab n P g F].
-Implicit Arguments Even_Partition [a b].
-Implicit Arguments Even_Partition_Sum [a b].
-Implicit Arguments Refinement [a b Hab n m].
+Arguments Partition [a b].
+Arguments Partition_Dom [a b Hab n].
+Arguments Mesh [a b Hab n].
+Arguments AntiMesh [a b Hab n].
+Arguments Pts [a b Hab lng].
+Arguments Part_Mesh_List [n a b Hab].
+Arguments Points_in_Partition [a b Hab n].
+Arguments Partition_Sum [a b Hab n P g F].
+Arguments Even_Partition [a b].
+Arguments Even_Partition_Sum [a b].
+Arguments Refinement [a b Hab m n].
 
 Hint Resolve start finish: algebra.
 
@@ -803,8 +803,8 @@ Definition Separated := _Separated _ P and _Separated _ Q and
 
 End More_Definitions.
 
-Implicit Arguments _Separated [a b Hab n].
-Implicit Arguments Separated [a b Hab n m].
+Arguments _Separated [a b Hab n].
+Arguments Separated [a b Hab n m].
 
 Section Sep_Partitions.
 

--- a/logic/CLogic.v
+++ b/logic/CLogic.v
@@ -325,7 +325,7 @@ Fixpoint member (A : Type) (n : A) (l : list A) {struct l} : CProp :=
   | cons y m => member A n m or y = n
   end.
 
-Implicit Arguments member [A].
+Arguments member [A].
 
 Section TRelation_Definition.
 (**
@@ -678,8 +678,8 @@ Definition nat_less_n_pred (n : nat) (P : forall i : nat, i < n -> CProp) :=
 Definition nat_less_n_pred' (n : nat) (P : forall i : nat, i <= n -> CProp) :=
   forall i j : nat, i = j -> forall (H : i <= n) (H' : j <= n), P i H -> P j H'.
 
-Implicit Arguments nat_less_n_pred [n].
-Implicit Arguments nat_less_n_pred' [n].
+Arguments nat_less_n_pred [n].
+Arguments nat_less_n_pred' [n].
 
 Section Odd_and_Even.
 

--- a/logic/CornBasics.v
+++ b/logic/CornBasics.v
@@ -812,7 +812,7 @@ Section AccT.
 Variable A : Type.
 Definition well_founded (P : A -> A -> Prop) := forall a : A, Acc _ P a.
 End AccT.
-Implicit Arguments Acc [A].
+Arguments Acc [A].
 
 Section IndT.
 Variable A : Type.
@@ -950,7 +950,7 @@ match n with
 |S m => z :: (iterateN A f (f z) m)
 end.
 (* begin hide *)
-Implicit Arguments iterateN [A].
+Arguments iterateN [A].
 (* end hide *)
 Lemma iterateN_f : forall A f (z:A) n, iterateN f (f z) n = map f (iterateN f z n).
 Proof.

--- a/metric2/Classified.v
+++ b/metric2/Classified.v
@@ -403,7 +403,7 @@ Class MetricSpaceComponents X `{Equiv X} `{MetricSpaceBall X}: Prop.
  we will use these to automatically derive uniform continuity for various forms of function
  composition). *)
 
-Implicit Arguments mspc_ball [[X] [MetricSpaceBall]].
+Arguments mspc_ball {X MetricSpaceBall}.
 
 Class Canonical (T: Type): Type := canonical: T.
   (* Todo: Move. *)
@@ -539,7 +539,7 @@ Section uniform_continuity.
 
 End uniform_continuity.
 
-Implicit Arguments uc_mu [[X] [Y] [UniformlyContinuous_mu]].
+Arguments uc_mu {X Y} f {UniformlyContinuous_mu}.
 
 (** Local uniform continuity just means that the function restricted to any finite balls
  is uniformly continuous: *)
@@ -657,8 +657,8 @@ End shallowly_wrapped_ucfuns.
 Existing Instance ucFun_mu.
 Existing Instance ucFun_uc.
 
-Implicit Arguments UCFunction [[Xe] [Xb] [Yb] [Ye]].
-Implicit Arguments ucFunction [[X] [Xe] [Xb] [Y] [Yb] [Ye] [ucFun_mu] [ucFun_uc]].
+Arguments UCFunction X {Xe Xb} Y {Ye Yb}.
+Arguments ucFunction {X Xe Xb Y Ye Yb} _ {ucFun_mu ucFun_uc}.
 
 
 Section delegated_mspc.

--- a/metric2/Complete.v
+++ b/metric2/Complete.v
@@ -358,10 +358,10 @@ Qed.
 End RegularFunction.
 
 (* begin hide *)
-Implicit Arguments regFunEq_e_small [X].
-Implicit Arguments is_RegularFunction [X].
+Arguments regFunEq_e_small [X].
+Arguments is_RegularFunction [X].
 
-Implicit Arguments Cunit [X].
+Arguments Cunit [X].
 
 Add Parametric Morphism X : (@Cunit_fun X) with signature (@st_eq _) ==> (@st_eq _) as Cunit_wd.
 Proof.
@@ -509,7 +509,7 @@ Build_UniformlyContinuousFunction Cjoin_prf.
 
 End Cjoin.
 
-Implicit Arguments Cjoin [X].
+Arguments Cjoin [X].
 
 Section Cmap.
 

--- a/metric2/CompleteProduct.v
+++ b/metric2/CompleteProduct.v
@@ -162,7 +162,7 @@ Qed.
 End CompleteProduct.
 
 (* begin hide *)
-Implicit Arguments Couple [X Y].
-Implicit Arguments Cfst [X Y].
-Implicit Arguments Csnd [X Y].
+Arguments Couple [X Y].
+Arguments Cfst [X Y].
+Arguments Csnd [X Y].
 (* end hide *)

--- a/metric2/DistanceMetricSpace.v
+++ b/metric2/DistanceMetricSpace.v
@@ -20,7 +20,7 @@ Record DistanceMetricSpace: Type := Build_alt_MetricSpace
     distance_wd: Proper (@st_eq _ ==> @st_eq _ ==> NNUpperR.eq) distance;
     dmsp : is_DistanceMetricSpace dmsp_is_setoid distance }.
 
-Implicit Arguments distance [d].
+Arguments distance [d].
 Existing Instance distance_wd.
 
 Section DistanceMetricSpace. (* Just mimicking Russell's code for MetricSpace here. *)

--- a/metric2/FinEnum.v
+++ b/metric2/FinEnum.v
@@ -565,7 +565,7 @@ End Strong.
 
 End Finite.
 (* begin hide *)
-Implicit Arguments InFinEnumC [X].
+Arguments InFinEnumC [X].
 (* end hide *)
 (** A list is equivalent to it's reverse as finite enumerations *)
 Lemma FinEnum_eq_rev : forall X (stable: stableMetric X) (f:FinEnum stable),
@@ -671,7 +671,7 @@ Proof.
  right; assumption.
 Qed.
 (* begin hide *)
-Implicit Arguments FinEnum_map_uc [X Y].
+Arguments FinEnum_map_uc z [X Y].
 (* end hide *)
 Definition FinEnum_map z X Y (SX:stableMetric X) (SY:stableMetric Y) (f:X --> Y) :=
  Build_UniformlyContinuousFunction (FinEnum_map_uc z SX SY f).

--- a/metric2/Limit.v
+++ b/metric2/Limit.v
@@ -36,8 +36,8 @@ this proof to only be used in proofs of termination. *)
 Inductive LazyExists {A} (P : Stream A → Prop) (x : Stream A) : Prop :=
   | LazyHere : P x → LazyExists P x
   | LazyFurther : (unit → LazyExists P (tl x)) → LazyExists P x.
-Implicit Arguments LazyHere [[A] [P] [x]].
-Implicit Arguments LazyFurther [[A] [P] [x]].
+Arguments LazyHere {A P x}.
+Arguments LazyFurther {A P x}.
 
 Instance LazyExists_proper `{Setoid A} `{!Proper ((=) ==> iff) (P : Stream A → Prop)} : Proper ((=) ==> iff) (LazyExists P).
 Proof.
@@ -403,6 +403,6 @@ Defined.
 
 End Limit.
 (* begin hide *)
-Implicit Arguments NearBy [X].
-Implicit Arguments Limit [X].
+Arguments NearBy [X].
+Arguments Limit [X].
 (* end hide *)

--- a/metric2/Metric.v
+++ b/metric2/Metric.v
@@ -63,12 +63,12 @@ Record MetricSpace : Type :=
 }.
 
 (* begin hide *)
-Implicit Arguments ball [m].
+Arguments ball [m].
 
 (*This is intended to be used as a ``type cast'' that Coq won't randomly make disappear.
   It is useful when defining setoid rewrite lemmas for st_eq.*)
 Definition ms_id (m:MetricSpace) (x:m) : m := x.
-Implicit Arguments ms_id [m].
+Arguments ms_id [m].
 
 Add Parametric Morphism (m:MetricSpace) : (@ball m) with signature QposEq ==> (@st_eq m) ==> (@st_eq m) ==> iff as ball_compat.
 Proof.

--- a/metric2/MetricMorphisms.v
+++ b/metric2/MetricMorphisms.v
@@ -53,7 +53,7 @@ Section metric_embedding.
 End metric_embedding.
 
 Class AppInverse `(f : X → Y) := app_inverse : Y → Qpos → X.
-Implicit Arguments app_inverse [[X] [Y] [AppInverse]].
+Arguments app_inverse {X Y} f {AppInverse}.
 
 Class DenseEmbedding `{Equiv X} {Y : MetricSpace} (f : X → Y) `{!AppInverse f} := {
   dense_embed_setoid : Setoid X ;

--- a/metric2/ProductMetric.v
+++ b/metric2/ProductMetric.v
@@ -193,7 +193,7 @@ Definition PairMS (x:X) (y:Y) : ProductMS := (x,y).
 
 End ProductMetric.
 (* begin hide *)
-Implicit Arguments PairMS [X Y].
+Arguments PairMS [X Y].
 
 Add Parametric Morphism X Y : (@PairMS X Y) with signature (@st_eq _) ==> (@st_eq _) ==> (@st_eq _) as PairMS_wd.
 Proof.

--- a/metric2/StepFunctionSetoid.v
+++ b/metric2/StepFunctionSetoid.v
@@ -68,7 +68,7 @@ Definition SplitR : StepF -> OpenUnit -> StepF := (@SplitR X).
 End StepF_Functions.
 
 (* begin hide *)
-Implicit Arguments constStepF [X].
+Arguments constStepF [X].
 (* end hide *)
 Local Open Scope setoid_scope.
 

--- a/metric2/UniformContinuity.v
+++ b/metric2/UniformContinuity.v
@@ -36,7 +36,7 @@ Definition ball_ex (X: MetricSpace) (e: QposInf): X -> X -> Prop :=
   | QposInfinity => fun a b => True
  end.
 (* begin hide *)
-Implicit Arguments ball_ex [X].
+Arguments ball_ex [X].
 (* end hide *)
 Lemma ball_ex_weak_le : forall (X:MetricSpace) (e d:QposInf) (a b:X), QposInf_le e d ->  ball_ex e a b -> ball_ex d a b.
 Proof.
@@ -193,7 +193,7 @@ Qed.
 End UniformlyContinuousFunction.
 
 (* begin hide *)
-Implicit Arguments is_UniformlyContinuousFunction [X Y].
+Arguments is_UniformlyContinuousFunction [X Y].
 
 (*
 Add Setoid UniformlyContinuousFunction ucEq uc_setoid as uc_Setoid.

--- a/metrics/CMetricSpaces.v
+++ b/metrics/CMetricSpaces.v
@@ -136,7 +136,7 @@ Definition Prod0CMetricSpace (X Y : CMetricSpace) :=
 (**
 A subspace of a metric space is again a metric space.
 *)
-Implicit Arguments SubPsMetricSpace [X].
+Arguments SubPsMetricSpace [X].
 
 Lemma SubMetricSpace_apdiag_grzero :
  forall (X : CMetricSpace) (P : X -> CProp),
@@ -157,7 +157,7 @@ Qed.
 Definition SubMetricSpace (X : CMetricSpace) (P : X -> CProp) :=
   Build_CMetricSpace (SubPsMetricSpace P) (SubMetricSpace_apdiag_grzero X P).
 
-Implicit Arguments SubMetricSpace [X].
+Arguments SubMetricSpace [X].
 
 End prodandsub.
 Section Zeroff.
@@ -572,7 +572,7 @@ Section Limitt.
 (**
 A sequence in a metric space has at most one limit.
 *)
-Implicit Arguments MSseqLimit [X].
+Arguments MSseqLimit [X].
 
 (* begin hide *)
 Lemma nz : forall n m : nat, n <= max n m.

--- a/metrics/CPMSTheory.v
+++ b/metrics/CPMSTheory.v
@@ -56,7 +56,7 @@ Fixpoint MSmember (X : CSetoid) (x : X) (l : list X) {struct l} : CProp :=
   | cons y m => MSmember X x m or x = y
   end.
 
-Implicit Arguments MSmember [X].
+Arguments MSmember [X].
 
 Definition to_IR (P : IR -> CProp) : subcsetoid_crr IR P -> IR.
 Proof.
@@ -209,7 +209,7 @@ Proof.
  exact H3.
 Qed.
 
-Implicit Arguments MSmember [X].
+Arguments MSmember [X].
 (**
 Again we see that the image under a certain mapping of an element of a list $l$
 #<I>l</I># is member of the list of images of elements of $l$ #<I>l</I>#.
@@ -251,7 +251,7 @@ Definition MStotally_bounded (X : CPsMetricSpace) : CProp :=
 Total boundedness is preserved under uniformly continuous mappings.
 *)
 
-Implicit Arguments SubPsMetricSpace [X].
+Arguments SubPsMetricSpace [X].
 Lemma unicon_resp_totallybounded :
  forall (X Z : CPsMetricSpace) (f : CSetoid_fun X Z) (H : uni_continuous'' f),
  MStotally_bounded X ->
@@ -452,7 +452,7 @@ elements $x$#<I>x</I># of $X$#<I>X</I># there exists an infimum for the distance
 between $x$#<I>x</I># and the elements of $P$#<I>P</I>#.
 *)
 
-Implicit Arguments dsub'_as_cs_fun [X].
+Arguments dsub'_as_cs_fun [X].
 
 Definition located (X : CPsMetricSpace) (P : X -> CProp) :=
   forall (x : X) (r : SubPsMetricSpace P),
@@ -460,7 +460,7 @@ Definition located (X : CPsMetricSpace) (P : X -> CProp) :=
   set_glb_IR
     (fun v : IR => {y : SubPsMetricSpace P | dsub'_as_cs_fun P x y[=]v}) z}.
 
-Implicit Arguments located [X].
+Arguments located [X].
 
 Definition located' (X : CPsMetricSpace) (P : X -> CProp) :=
   forall (x : X) (y : SubPsMetricSpace P),
@@ -469,7 +469,7 @@ Definition located' (X : CPsMetricSpace) (P : X -> CProp) :=
     (fun v : IR =>
      {y : SubPsMetricSpace P | x[-d]from_SubPsMetricSpace X P y[=]v}) z}.
 
-Implicit Arguments located' [X].
+Arguments located' [X].
 
 Lemma located_imp_located' :
  forall (X : CPsMetricSpace) (P : X -> CProp), located P -> located' P.
@@ -725,7 +725,7 @@ Definition MSCauchy_seq (X : CPsMetricSpace) (seq : nat -> X) : CProp :=
   {m : nat |
   forall i j : nat, m <= i -> m <= j -> seq i[-d]seq j[<=]one_div_succ n}.
 
-Implicit Arguments MSseqLimit' [X].
+Arguments MSseqLimit' [X].
 
 Definition MSComplete (X : CPsMetricSpace) : CProp :=
   forall seq : nat -> X,
@@ -748,7 +748,7 @@ Definition open (X : CPsMetricSpace) (P : X -> CProp) :=
   forall x : X,
   P x -> {e : IR | [0][<]e and (forall z : X, z[-d]x[<]e -> P z)}.
 
-Implicit Arguments open [X].
+Arguments open [X].
 
 (**
 The operator [infima] gives the infimum for the distance between an
@@ -766,7 +766,7 @@ Proof.
  exact x.
 Defined.
 
-Implicit Arguments infima [X].
+Arguments infima [X].
 (**
 A non-empty totally bounded sub-pseudo-metric-space $P$#<I>P</I># is said to be
 %\emph{well contained}% #<I>well contained</I># in an open sub-pseudo-metric-space $Q$#<I>Q</I># if $Q$#<I>Q</I># contains

--- a/metrics/CPseudoMSpaces.v
+++ b/metrics/CPseudoMSpaces.v
@@ -96,7 +96,7 @@ Record CPsMetricSpace : Type :=
 
 End Definition_PsMS0.
 
-Implicit Arguments cms_d [c].
+Arguments cms_d [c].
 Infix "[-d]" := cms_d (at level 68, left associativity).
 
 

--- a/metrics/ContFunctions.v
+++ b/metrics/ContFunctions.v
@@ -88,14 +88,14 @@ Definition lipschitz_c (f : CSetoid_fun A B) (C : IR) : CProp :=
     forall x1 x2 : A, f x1 [-d] f x2 [<=] C [*] (x1 [-d] x2).
 
 End Continuous_functions.
-Implicit Arguments continuous [A B].
-Implicit Arguments uni_continuous [A B].
-Implicit Arguments lipschitz [A B].
-Implicit Arguments continuous' [A B].
-Implicit Arguments uni_continuous' [A B].
-Implicit Arguments uni_continuous'' [A B].
-Implicit Arguments lipschitz' [A B].
-Implicit Arguments lipschitz_c [A B].
+Arguments continuous [A B].
+Arguments uni_continuous [A B].
+Arguments lipschitz [A B].
+Arguments continuous' [A B].
+Arguments uni_continuous' [A B].
+Arguments uni_continuous'' [A B].
+Arguments lipschitz' [A B].
+Arguments lipschitz_c [A B].
 
 Section Lemmas.
 
@@ -603,14 +603,14 @@ Definition MSseqLimit (X : CPsMetricSpace) (seq : nat -> X)
   {N : nat |
   forall m : nat, N <= m -> seq m[-d]lim[<]([1][/] Two:IR[//]H)[^]n}.
 
-Implicit Arguments MSseqLimit [X].
+Arguments MSseqLimit [X].
 
 Definition MSseqLimit' (X : CPsMetricSpace) (seq : nat -> X)
   (lim : X) : CProp :=
   forall n : nat,
   {N : nat | forall m : nat, N <= m -> seq m[-d]lim[<=]one_div_succ n}.
 
-Implicit Arguments MSseqLimit' [X].
+Arguments MSseqLimit' [X].
 
 Lemma MSseqLimit_imp_MSseqLimit' :
  forall (X : CPsMetricSpace) (seq : nat -> X) (lim : X),
@@ -677,7 +677,7 @@ Definition seqcontinuous' (A B : CPsMetricSpace) (f : CSetoid_fun A B) :
   forall (seq : nat -> A) (lim : A),
   MSseqLimit' seq lim -> MSseqLimit' (fun m : nat => f (seq m)) (f lim).
 
-Implicit Arguments seqcontinuous' [A B].
+Arguments seqcontinuous' [A B].
 
 Lemma continuous'_imp_seqcontinuous' :
  forall (A B : CPsMetricSpace) (f : CSetoid_fun A B),

--- a/metrics/Equiv.v
+++ b/metrics/Equiv.v
@@ -56,7 +56,7 @@ Definition isopsmetry (X Y : CPsMetricSpace) (f : CSetoid_fun X Y) :=
   and equivalent_psmetric X (cms_d (c:=X))
         (compose_CSetoid_bin_un_fun X Y IR (cms_d (c:=Y)) f).
 
-Implicit Arguments isopsmetry [X Y].
+Arguments isopsmetry [X Y].
 
 Lemma isopsmetry_imp_bij :
  forall (X Y : CPsMetricSpace) (f : CSetoid_fun X Y),

--- a/metrics/Prod_Sub.v
+++ b/metrics/Prod_Sub.v
@@ -206,7 +206,7 @@ Definition restr_bin_fun (X : CPsMetricSpace) (P : cms_crr X -> CProp)
   end.
 
 
-Implicit Arguments restr_bin_fun [X].
+Arguments restr_bin_fun [X].
 
 Definition restr_bin_fun' (X : CPsMetricSpace) (P : cms_crr X -> CProp)
   (f : CSetoid_bin_fun X X IR) (a : X) (b : Build_SubCSetoid X P) : IR :=
@@ -214,7 +214,7 @@ Definition restr_bin_fun' (X : CPsMetricSpace) (P : cms_crr X -> CProp)
   | Build_subcsetoid_crr _ _ y q => f a y
   end.
 
-Implicit Arguments restr_bin_fun' [X].
+Arguments restr_bin_fun' [X].
 
 Lemma restr_bin_fun_strext :
  forall (X : CPsMetricSpace) (P : cms_crr X -> CProp)
@@ -242,7 +242,7 @@ Definition Build_SubCSetoid_bin_fun (X : CPsMetricSpace)
 Definition dsub (X : CPsMetricSpace) (P : cms_crr X -> CProp) :=
   Build_SubCSetoid_bin_fun X P (cms_d (c:=X)).
 
-Implicit Arguments dsub [X].
+Arguments dsub [X].
 
 Lemma dsub_com :
  forall (X : CPsMetricSpace) (P : cms_crr X -> CProp), com (dsub P).
@@ -317,7 +317,7 @@ Definition SubPsMetricSpace (X : CPsMetricSpace) (P : cms_crr X -> CProp) :
   Build_CPsMetricSpace (Build_SubCSetoid X P) (dsub P)
     (is_SubPsMetricSpace X P).
 
-Implicit Arguments SubPsMetricSpace [X].
+Arguments SubPsMetricSpace [X].
 
 Definition from_SubPsMetricSpace (X : CPsMetricSpace)
   (P : X -> CProp) : SubPsMetricSpace P -> X.
@@ -339,7 +339,7 @@ pseudo metric space and a certain subspace.
 Definition dsub' (X : CPsMetricSpace) (P : X -> CProp)
   (x : X) (y : SubPsMetricSpace P) := from_SubPsMetricSpace X P y[-d]x.
 
-Implicit Arguments dsub' [X].
+Arguments dsub' [X].
 
 Lemma dsub'_strext :
  forall (X : CPsMetricSpace) (P : X -> CProp) (x : X),
@@ -367,7 +367,7 @@ Definition dsub'_as_cs_fun (X : CPsMetricSpace) (P : X -> CProp)
   Build_CSetoid_fun (SubPsMetricSpace P) IR_as_CPsMetricSpace (
     dsub' P x) (dsub'_strext X P x).
 
-Implicit Arguments dsub'_as_cs_fun [X].
+Arguments dsub'_as_cs_fun [X].
 
 Lemma dsub'_uni_continuous'' :
  forall (X : CPsMetricSpace) (P : X -> CProp) (x : X),

--- a/model/metric2/LinfDistMonad.v
+++ b/model/metric2/LinfDistMonad.v
@@ -133,7 +133,7 @@ Proof.
 Defined.
 End Dist.
 
-Implicit Arguments dist [X].
+Arguments dist [X].
 
 Definition distconst(X : MetricSpace):(Complete X)->Complete (StepFSup X).
 Proof.

--- a/model/metric2/LinfMetricMonad.v
+++ b/model/metric2/LinfMetricMonad.v
@@ -81,7 +81,7 @@ Qed.
 
 End StepFSupBall.
 
-Implicit Arguments StepFSupBall [X].
+Arguments StepFSupBall [X].
 
 Add Parametric Morphism X : (@StepFSupBall X)
   with signature QposEq ==> (@StepF_eq _) ==> (@StepF_eq _) ==> iff
@@ -379,4 +379,4 @@ Definition constStepF_uc : X --> StepFSup X
 
 End UniformlyContinuousFunctions.
 
-Implicit Arguments constStepF_uc [X].
+Arguments constStepF_uc [X].

--- a/model/structures/Qpossec.v
+++ b/model/structures/Qpossec.v
@@ -105,7 +105,7 @@ Hint Immediate Qopp_Qpos_neg.
 Definition mkQpos: forall (a:Q) (p:0 < a), Qpos := @exist Q (Qlt 0).
 
 (* begin hide *)
-Implicit Arguments mkQpos [a].
+Arguments mkQpos [a].
 (* end hide *)
 Lemma QposAsmkQpos : forall (a:Q) (p:0<a), (QposAsQ (mkQpos p))=a.
 Proof.
@@ -115,7 +115,7 @@ Proof.
  discriminate.
 Qed.
 (* begin hide *)
-Implicit Arguments QposAsmkQpos [a].
+Arguments QposAsmkQpos [a].
 (* end hide *)
 
 Lemma positive_Z (z: Z): Zlt 0 z -> sig (fun p: positive => Zpos p = z).
@@ -322,7 +322,7 @@ Proof.
  QposRing.
 Defined.
 (* begin hide *)
-Implicit Arguments Qpos_lt_plus [a b].
+Arguments Qpos_lt_plus [a b].
 (* end hide *)
 (**
 *** Power

--- a/ode/SimpleIntegration.v
+++ b/ode/SimpleIntegration.v
@@ -36,7 +36,7 @@ Proof. rewrite <- ball_gball; reflexivity. Qed.
 
 Class Integral (f: Q → CR) := integrate: forall (from: Q) (w: QnonNeg), CR.
 
-Implicit Arguments integrate [[Integral]].
+Arguments integrate f {Integral}.
 
 Notation "∫" := integrate.
 

--- a/order/Lattice.v
+++ b/order/Lattice.v
@@ -35,7 +35,7 @@ Record Lattice : Type :=
 ; l_proof : is_SemiLattice (Dual sl) join
 }.
 (* begin hide *)
-Implicit Arguments join [l].
+Arguments join [l].
 (* end hide*)
 Section Join.
 

--- a/order/SemiLattice.v
+++ b/order/SemiLattice.v
@@ -44,7 +44,7 @@ Record SemiLattice : Type :=
 }.
 
 (* begin hide *)
-Implicit Arguments meet [s].
+Arguments meet [s].
 
 Add Parametric Morphism (X:SemiLattice) : (@meet X) with signature (@st_eq X) ==> (@st_eq X) ==> (@st_eq X)  as meet_compat.
 Proof.

--- a/reals/CMetricFields.v
+++ b/reals/CMetricFields.v
@@ -169,4 +169,4 @@ Definition is_MCauchyCompl (lim : MCauchySeq -> F) : CProp :=
 
 End CMetric_Field_Cauchy.
 
-Implicit Arguments MseqLimit [F].
+Arguments MseqLimit [F].

--- a/reals/CReals.v
+++ b/reals/CReals.v
@@ -63,4 +63,4 @@ Record CReals : Type :=
 
 Definition Lim : forall IR : CReals, CauchySeq IR -> IR := crl_lim.
 
-Implicit Arguments Lim [IR].
+Arguments Lim [IR].

--- a/reals/Intervals.v
+++ b/reals/Intervals.v
@@ -132,7 +132,7 @@ Defined.
 End Intervals.
 
 Notation Compact := (compact _ _).
-Implicit Arguments Frestr [F P].
+Arguments Frestr [F P].
 Notation FRestr := (Frestr (compact_wd _ _ _)).
 
 Section More_Intervals.

--- a/reals/NRootIR.v
+++ b/reals/NRootIR.v
@@ -222,7 +222,7 @@ Qed.
 
 End Nth_Root.
 
-Implicit Arguments NRoot [x n].
+Arguments NRoot [x n].
 
 Hint Resolve NRoot_power NRoot_power': algebra.
 

--- a/reals/RealLists.v
+++ b/reals/RealLists.v
@@ -78,7 +78,7 @@ Definition length_leEq (A : Type) (l : list A) (n : nat) := length l <= n.
 
 (** Length is preserved by mapping. *)
 
-Implicit Arguments map [A B].
+Arguments map [A B].
 
 Lemma map_pres_length : forall (A B : Set) (l : list A) (f : A -> B),
  length l = length (map f l).
@@ -92,7 +92,7 @@ Qed.
 (**
 Often we want to map partial functions through a list; this next operator provides a way to do that, and is proved to be correct. *)
 
-Implicit Arguments cons [A].
+Arguments cons [A].
 
 Definition map2 (F : PartIR) (l : list IR) :
  (forall y, member y l -> Dom F y) -> list IR.

--- a/reals/fast/CRFieldOps.v
+++ b/reals/fast/CRFieldOps.v
@@ -368,7 +368,7 @@ Proof with simpl in *; auto with *.
 Qed.
 
 (* begin hide *)
-Implicit Arguments Qmult_uc_prf [].
+Arguments Qmult_uc_prf : clear implicits.
 (* end hide *)
 Definition Qmult_uc (c:Qpos) :  Q_as_MetricSpace --> Q_as_MetricSpace --> Q_as_MetricSpace:=
 Build_UniformlyContinuousFunction (Qmult_uc_prf c).
@@ -625,7 +625,7 @@ Proof.
  apply Ha.
 Qed.
 
-Implicit Arguments Qinv_pos_uc_prf [].
+Arguments Qinv_pos_uc_prf : clear implicits.
 
 Definition Qinv_pos_uc (c:Qpos) : Q_as_MetricSpace --> Q_as_MetricSpace :=
 Build_UniformlyContinuousFunction (Qinv_pos_uc_prf c).
@@ -718,7 +718,7 @@ Proof.
  exact (CRinv_pos c x).
 Defined.
 
-Implicit Arguments CRinvT [].
+Arguments CRinvT : clear implicits.
 
 Lemma CRinvT_pos_inv : forall (c:Qpos) (x:CR) x_,
  ('c <= x ->

--- a/reals/fast/CRconst.v
+++ b/reals/fast/CRconst.v
@@ -22,4 +22,4 @@ Section const_fun_uc.
    Build_UniformlyContinuousFunction (const_uc_prf).
 End const_fun_uc.
 
-Implicit Arguments const_uc [[X]].
+Arguments const_uc {X}.

--- a/reals/fast/CRexp.v
+++ b/reals/fast/CRexp.v
@@ -736,7 +736,7 @@ Qed.
 is known to be bounded by some intenger. *)
 Definition exp (x:CR) : CR := exp_bounded (Qceiling (approximate x ((1#1)%Qpos) + (1#1))) x.
 (* begin hide *)
-Implicit Arguments exp [].
+Arguments exp : clear implicits.
 (* end hide *)
 Lemma exp_bound_lemma : forall x : CR, (x <= ' (approximate x (1 # 1)%Qpos + 1)%Q)%CR.
 Proof.

--- a/reals/fast/CRln.v
+++ b/reals/fast/CRln.v
@@ -379,7 +379,7 @@ Qed.
 Definition CRln (x:CR) (Hx:(0 < x)%CR) : CR :=
 let (c,_) := Hx in CRln_pos c x.
 (* begin hide *)
-Implicit Arguments CRln [].
+Arguments CRln : clear implicits.
 (* end hide *)
 Lemma CRln_correct : forall x Hx Hx0, (IRasCR (Log x Hx)==CRln (IRasCR x) Hx0)%CR.
 Proof.

--- a/tactics/AlgReflection.v
+++ b/tactics/AlgReflection.v
@@ -498,8 +498,8 @@ Fixpoint Mnth (n:nat) (l:metalist) (default:A) {struct l} : A :=
   end.
 
 End MetaList.
-Implicit Arguments Mcons [A].
-Implicit Arguments Mnth [A].
+Arguments Mcons [A].
+Arguments Mnth [A].
 
 Ltac FindIndex t l :=
 match l with
@@ -519,6 +519,6 @@ Variable A B C D: Type.
 Inductive quadruple : Type :=
  Quad : A -> B -> C -> D -> quadruple.
 End Quadruple.
-Implicit Arguments Quad [A B C D].
+Arguments Quad [A B C D].
 
 (* end hide *)


### PR DESCRIPTION
The Implicit Arguments command is deprecated, and was causing lots of warnings in Travis.

See also coq/coq#6802.