### PR TITLE
Get rid of `'` notation

### DIFF
--- a/reals/fast/CRIR.v
+++ b/reals/fast/CRIR.v
@@ -319,7 +319,7 @@ Proof.
    ' (n # 1)%Q * ' (/ (d # 1))%Q)%CR).
  rewrite <- (CRinv_Qinv d d__).
  unfold cf_div.
- assert (X:(forall (n:positive), IRasCR (nring (R:=IR) (nat_of_P n)) == ' ('n)%Z)%CR).
+ assert (X:(forall (n:positive), IRasCR (nring (R:=IR) (nat_of_P n)) == ' Zpos n)%CR).
   intros x.
   clear -x.
   rewrite <- convert_is_POS.

--- a/reals/fast/CRsum.v
+++ b/reals/fast/CRsum.v
@@ -80,8 +80,8 @@ Proof.
   autorewrite with QposElim.
   apply Qplus_le_compat; auto.
  simpl in *.
- change ('P_of_succ_nat (length t))%Z with (Z_of_nat (1+(length t))) in H1.
- change ('P_of_succ_nat (length t))%Z with (Z_of_nat (1+(length t))) in H2.
+ change (Zpos (P_of_succ_nat (length t))) with (Z_of_nat (1+(length t))) in H1.
+ change (Zpos (P_of_succ_nat (length t))) with (Z_of_nat (1+(length t))) in H2.
  rewrite ->  inj_plus in *.
  rewrite ->  injz_plus in *.
  ring_simplify in H1.

--- a/reals/fast/PowerBound.v
+++ b/reals/fast/PowerBound.v
@@ -44,7 +44,7 @@ Proof.
  apply Zle_trans with (two_p (Zsucc (log_inf n))-1)%Z.
   rewrite <- Zle_plus_swap.
   apply Zlt_succ_le.
-  change (' n+1) with (Zsucc ('n)).
+  change (Zpos n+1) with (Zsucc (Zpos n)).
   apply Zsucc_lt_compat.
   destruct (log_inf_correct2 n).
   assumption.
@@ -71,7 +71,7 @@ Proof.
  intros q.
  eapply Qle_trans.
   apply power3bound.
- generalize (let (n, _) := q in match n with | 0 => 0%nat | ' p => Psize p | Zneg _ => 0%nat end)%Z.
+ generalize (let (n, _) := q in match n with | 0 => 0%nat | Zpos p => Psize p | Zneg _ => 0%nat end)%Z.
  intros n.
  unfold Qle.
  simpl.

--- a/stdlib_omissions/Q.v
+++ b/stdlib_omissions/Q.v
@@ -48,7 +48,7 @@ Proof. reflexivity. Qed.
 Lemma S_Qplus (n: nat): inject_Z (Z_of_nat (S n)) = inject_Z (Z_of_nat n) + 1.
 Proof. rewrite inj_S. apply Zplus_Qplus. Qed.
 
-Lemma Pmult_Qmult (x y: positive): inject_Z (' (Pmult x y)) = inject_Z (' x) * inject_Z (' y).
+Lemma Pmult_Qmult (x y: positive): inject_Z (Zpos (Pmult x y)) = inject_Z (Zpos x) * inject_Z (Zpos y).
 Proof. rewrite Zpos_mult_morphism. apply Zmult_Qmult. Qed.
 
 Lemma Zle_Qle (x y: Z): (x <= y)%Z = (inject_Z x <= inject_Z y).
@@ -405,7 +405,7 @@ Proof with intuition.
  destruct Qnum.
    change (x * 0 <= 1).
    rewrite Qmult_0_r...
-  rewrite <- (Qmult_inv_r ('p # Qden)).
+  rewrite <- (Qmult_inv_r (Zpos p # Qden)).
    unfold Qdiv.
    apply Qmult_le_compat_r...
   discriminate.
@@ -470,7 +470,7 @@ Hint Resolve inject_Z_nonneg.
 
 Lemma positive_in_Q (p: positive): 0 < inject_Z (Zpos p).
 Proof.
- change (inject_Z 0 < inject_Z (' p)).
+ change (inject_Z 0 < inject_Z (Zpos p)).
  rewrite <- Zlt_Qlt.
  reflexivity.
 Qed.


### PR DESCRIPTION
Get rid of `'` to provide compatibility with https://github.com/coq/coq/pull/6155
    
This change is backwards compatible.