### PR TITLE
Backward compatible fix for coq/coq#7451.

### DIFF
--- a/reals/CMetricFields.v
+++ b/reals/CMetricFields.v
@@ -36,6 +36,8 @@
 
 Require Export CoRN.reals.CReals1.
 
+Set Nested Proofs Allowed.
+
 Section CMetric_Fields.
 
 (**


### PR DESCRIPTION
coq/coq#7451 forbids the use of nested lemmas unless option Nested Proofs Allowed is turned off.
This PR adds the option in the only file that was using nested lemmas.
The fix is backward compatible because unknown options do not result in a failure but just in a warning.