### PR TITLE
Adapt to the deprecation of positive coinductive types.

### DIFF
--- a/metric2/Limit.v
+++ b/metric2/Limit.v
@@ -22,7 +22,7 @@ CONNECTION WITH THE PROOF OR THE USE OR OTHER DEALINGS IN THE PROOF.
 Require Import Coq.QArith.QArith.
 Require Import Coq.Bool.Bool.
 Require Export CoRN.metric2.Complete.
-Require Export Coq.Lists.Streams.
+Require Export MathClasses.theory.Streams.
 Require Import MathClasses.interfaces.abstract_algebra MathClasses.theory.streams MathClasses.orders.naturals.
 
 (**

--- a/metric2/UCFnMonoid.v
+++ b/metric2/UCFnMonoid.v
@@ -1,4 +1,4 @@
-Require Import Coq.Unicode.Utf8 Coq.Lists.Streams CoRN.metric2.UniformContinuity MathClasses.interfaces.abstract_algebra.
+Require Import Coq.Unicode.Utf8 MathClasses.theory.Streams CoRN.metric2.UniformContinuity MathClasses.interfaces.abstract_algebra.
 
 
 (** Uniform continuous maps from a metric space to itself (endomaps)

--- a/reals/fast/CRAlternatingSum.v
+++ b/reals/fast/CRAlternatingSum.v
@@ -32,7 +32,7 @@ Require Import CoRN.reals.fast.LazyNat.
 Require Export CoRN.metric2.Limit.
 Require Import CoRN.model.totalorder.QposMinMax.
 Require Import Coq.QArith.Qpower.
-Require Export Coq.Lists.Streams.
+Require Export MathClasses.theory.Streams.
 Require Import CoRN.transc.PowerSeries.
 Require Import CoRN.tactics.CornTac.
 Require Import CoRN.classes.Qclasses.


### PR DESCRIPTION
This PR is a backward compatible fix for PR coq/coq#7536, and the subsequent PR math-classes/math-classes#52. The same warning from the latter applies.
